### PR TITLE
feat: refine styling and vendor insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,16 @@ This project tracks daily announcements from analytics vendors (Microsoft, Sales
 - **`frontend/public/articles.json`** – structured data used by a React app
 - **Optional email digest** summarising the links
 
-The React app uses React Router to provide a home page plus separate vendor and industry sections. A global search bar filters all pages, and styling mimics ThoughtSpot's clean enterprise look.
+The React app uses React Router to provide a home page plus separate vendor and industry sections. A global search bar filters all pages, and styling mirrors ThoughtSpot's dark theme.
+
+Recent enhancements include:
+
+- Optional LLM-powered summaries for richer article context.
+- Vendor weaknesses framed against ThoughtSpot's search-driven analytics.
+- A "Top News" section highlighting priority competitors.
+- Expanded feed coverage for OpenAI, Anthropic, Google Looker/Gemini, Qlik and more.
+ - Home page capped to the 10 most relevant articles with vendor news first.
+ - Vendor folders collapsed by default and a single gradient background matching ThoughtSpot's palette.
 
 ---
 

--- a/feeds.yaml
+++ b/feeds.yaml
@@ -7,6 +7,10 @@ feeds:
     url: https://news.google.com/rss/search?q=Microsoft+Power+BI
     max_items: 5
     category: vendor
+  - name: Microsoft
+    url: https://news.google.com/rss/search?q=Microsoft+Copilot+Power+BI
+    max_items: 5
+    category: vendor
   - name: Salesforce
     url: https://news.google.com/rss/search?q=Salesforce+Tableau
     max_items: 5
@@ -19,12 +23,32 @@ feeds:
     url: https://www.snowflake.com/feed/
     max_items: 5
     category: vendor
+  - name: Snowflake
+    url: https://news.google.com/rss/search?q=Snowflake+Cortex
+    max_items: 5
+    category: vendor
   - name: Databricks
     url: https://www.databricks.com/feed
     max_items: 5
     category: vendor
+  - name: Databricks
+    url: https://news.google.com/rss/search?q=Databricks+Genie
+    max_items: 5
+    category: vendor
   - name: Sigma Computing
     url: https://www.sigmacomputing.com/blog/feed/
+    max_items: 5
+    category: vendor
+  - name: Qlik
+    url: https://news.google.com/rss/search?q=Qlik+analytics
+    max_items: 5
+    category: vendor
+  - name: Google
+    url: https://news.google.com/rss/search?q=Google+Looker
+    max_items: 5
+    category: vendor
+  - name: Google
+    url: https://news.google.com/rss/search?q=Google+Gemini
     max_items: 5
     category: vendor
   - name: Agentic Analytics
@@ -33,5 +57,13 @@ feeds:
     category: industry
   - name: Data Analytics
     url: https://news.google.com/rss/search?q=data+analytics
+    max_items: 5
+    category: industry
+  - name: OpenAI
+    url: https://news.google.com/rss/search?q=OpenAI
+    max_items: 5
+    category: industry
+  - name: Anthropic
+    url: https://news.google.com/rss/search?q=Anthropic
     max_items: 5
     category: industry

--- a/frontend/public/articles.json
+++ b/frontend/public/articles.json
@@ -6,7 +6,8 @@
     "published": "Mon, 28 Jul 2025 13:59:57 +0000",
     "source": "Microsoft",
     "category": "vendor",
-    "drawbacks": "Could require significant compute resources and expert oversight."
+    "drawbacks": "Power BI and Copilot tie insights to predefined models, unlike ThoughtSpot's flexible search-first UX.",
+    "fetched": "2025-08-04"
   },
   {
     "title": "Recommitting to our why, what, and how",
@@ -15,7 +16,8 @@
     "published": "Thu, 24 Jul 2025 16:19:41 +0000",
     "source": "Microsoft",
     "category": "vendor",
-    "drawbacks": "Could require significant compute resources and expert oversight."
+    "drawbacks": "Power BI and Copilot tie insights to predefined models, unlike ThoughtSpot's flexible search-first UX.",
+    "fetched": "2025-08-04"
   },
   {
     "title": "Announcing comprehensive sovereign solutions empowering European organizations",
@@ -24,7 +26,8 @@
     "published": "Mon, 16 Jun 2025 08:39:54 +0000",
     "source": "Microsoft",
     "category": "vendor",
-    "drawbacks": "May raise security and compliance concerns."
+    "drawbacks": "Power BI and Copilot tie insights to predefined models, unlike ThoughtSpot's flexible search-first UX. Security and compliance risks remain, an area where ThoughtSpot stresses governance.",
+    "fetched": "2025-08-04"
   },
   {
     "title": "Microsoft Build 2025: The age of AI agents and building the open agentic web",
@@ -33,7 +36,8 @@
     "published": "Mon, 19 May 2025 16:00:00 +0000",
     "source": "Microsoft",
     "category": "vendor",
-    "drawbacks": "Could require significant compute resources and expert oversight."
+    "drawbacks": "Power BI and Copilot tie insights to predefined models, unlike ThoughtSpot's flexible search-first UX.",
+    "fetched": "2025-08-04"
   },
   {
     "title": "How agentic AI is driving AI-first business transformation for customers to achieve more",
@@ -42,7 +46,8 @@
     "published": "Mon, 28 Apr 2025 15:59:56 +0000",
     "source": "Microsoft",
     "category": "vendor",
-    "drawbacks": "Could require significant compute resources and expert oversight."
+    "drawbacks": "Power BI and Copilot tie insights to predefined models, unlike ThoughtSpot's flexible search-first UX.",
+    "fetched": "2025-08-04"
   },
   {
     "title": "Copilot, agents, and apps at the Power Platform Community Conference 2025 - Microsoft",
@@ -51,7 +56,8 @@
     "published": "Thu, 31 Jul 2025 15:00:00 GMT",
     "source": "Microsoft",
     "category": "vendor",
-    "drawbacks": "Consider cost, adoption effort, and governance implications."
+    "drawbacks": "Power BI and Copilot tie insights to predefined models, unlike ThoughtSpot's flexible search-first UX.",
+    "fetched": "2025-08-04"
   },
   {
     "title": "How Microsoft Power BI Elevated My Data Analysis and Visualization Workflow - Towards Data Science",
@@ -60,7 +66,628 @@
     "published": "Tue, 27 May 2025 07:00:00 GMT",
     "source": "Microsoft",
     "category": "vendor",
-    "drawbacks": "Consider cost, adoption effort, and governance implications."
+    "drawbacks": "Power BI and Copilot tie insights to predefined models, unlike ThoughtSpot's flexible search-first UX.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Critical Salesforce Tableau Vulnerabilities Let Attackers Execute Code Remotely - CyberSecurityNews",
+    "link": "https://news.google.com/rss/articles/CBMic0FVX3lxTFBQNWR0ZlMwT0ZEdXFabENDTmJITHNjSXpQN0lKRU9NTld1b2lCMndET1RFX0R4Uzc1b25jdks3aWY4YzExNTlGV2l6aVBsNTFKWGdldFJVYXpXOW1ISHhLLXd0TUI2dHpuVHl6X0FqYThjYknSAXhBVV95cUxQN05UTDNKa1A4ejB3YklWcnJoRjQ4M19MbDkxVmlkY2NuQWxRSHhQS0NicVVZTTBrNzZVTFZZWWE3SnBFdzVXYURYdTVTRVBuNmkzb0IzWDlUYWxfTkllVzdzbFNpbU9BanpxaUN5eVYzZTNtQ2dPcWY?oc=5",
+    "summary": "Critical Salesforce Tableau Vulnerabilities Let Attackers Execute Code Remotely  CyberSecurityNews Critical Salesforce Tableau Vulnerabilities Let Attackers Execute Code Remotely  CyberSecurityNews",
+    "published": "Mon, 28 Jul 2025 06:06:42 GMT",
+    "source": "Salesforce",
+    "category": "vendor",
+    "drawbacks": "Tableau dashboards require curation whereas ThoughtSpot enables ad-hoc natural language exploration. Security and compliance risks remain, an area where ThoughtSpot stresses governance.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Salesforce Unveils Tableau Next: 5 Big Talking Points - CX Today",
+    "link": "https://news.google.com/rss/articles/CBMiogFBVV95cUxOV2s5NElSY1dxVU5Ma0lWWUpfUkRTN0trbExOOENCSWRkMXNBOGJRUzVGcmZfV1F6VWI1elRESWNmR2hLZEtwR2hCZHNVaUFGVGlSc1JRenB2dHd5amtiTF9sbjFVNWFRWHoxMVdhMmF6VVQxYmRvZXZsYmhXZFlBTTk2Q2V4R1g4VU04T1A3RXJ5UlVzX1ZjSllBczBld29PWXc?oc=5",
+    "summary": "Salesforce Unveils Tableau Next: 5 Big Talking Points  CX Today Salesforce Unveils Tableau Next: 5 Big Talking Points  CX Today",
+    "published": "Tue, 22 Apr 2025 07:00:00 GMT",
+    "source": "Salesforce",
+    "category": "vendor",
+    "drawbacks": "Tableau dashboards require curation whereas ThoughtSpot enables ad-hoc natural language exploration.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Critical Salesforce Tableau Flaws Allow Remote Code Execution – Patch Immediately! - gbhackers.com",
+    "link": "https://news.google.com/rss/articles/CBMiggFBVV95cUxQU2V0OFhvNzQ5Qm5LVV9TXzdFZUNLbHJHbVhaRG12bG45Uk5OS1dqMWh6LWxsa2VqZWtIN2dyMXhlUEpqM1BFT3NQMmZtWHJsUkxxWTU3b3RhMXdMQmhYdzNPUVBOSGZTUGFsX3JxWG1HeWdpQW1rTGdoUzdXSTZjcm530gGHAUFVX3lxTE43UVdmZFRzOEdQazgtUy00ejItX3R2dGRSNlRjbzZTZW41NUJuVXkzLTdzZFcwQm9nX0ZzY0NQU2s2Z2RCZWVwZ0tpVFNUeWdlNzQwaTR0VGtrUFRtci1hem5XM2tDNU5wcGR3TnpoQWxSVlgzRmtVZkxCY3NPZ2xCYVh0MFQ5OA?oc=5",
+    "summary": "Critical Salesforce Tableau Flaws Allow Remote Code Execution – Patch Immediately!  gbhackers.com Critical Salesforce Tableau Flaws Allow Remote Code Execution – Patch Immediately!  gbhackers.com",
+    "published": "Mon, 28 Jul 2025 04:56:24 GMT",
+    "source": "Salesforce",
+    "category": "vendor",
+    "drawbacks": "Tableau dashboards require curation whereas ThoughtSpot enables ad-hoc natural language exploration.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Severe Salesforce Tableau Vulnerabilities Enable Remote Code Execution – Urgent Patch Required - Cyber Press",
+    "link": "https://news.google.com/rss/articles/CBMidkFVX3lxTFBHemdaa2RTVGZibW8zYzZaZ1QxOGx5TnVuMUFkVk83YnNHNkhXNF9tZFNmc1NLVGFpeERPODIya0ZhM1Z3MzdoYVcwNEhWWmlzdFlGbG1YSXkyOUQzM2dPTU9PM3AzZzdVZzZSa2w2SUprMC1hb1HSAXZBVV95cUxQR3pnWmtkU1RmYm1vM2M2WmdUMThseU51bjFBZFZPN2JzRzZIVzRfbWRTZnNTS1RhaXhETzgyMmtGYTNWdzM3aGFXMDRIVlppc3RZRmxtWEl5MjlEMzNnT01PTzNwM2c3VWc2UmtsNklKazAtYW9R?oc=5",
+    "summary": "Severe Salesforce Tableau Vulnerabilities Enable Remote Code Execution – Urgent Patch Required  Cyber Press Severe Salesforce Tableau Vulnerabilities Enable Remote Code Execution – Urgent Patch Required  Cyber Press",
+    "published": "Mon, 28 Jul 2025 07:11:47 GMT",
+    "source": "Salesforce",
+    "category": "vendor",
+    "drawbacks": "Tableau dashboards require curation whereas ThoughtSpot enables ad-hoc natural language exploration.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Salesforce Agentforce: What you need to know - MarTech",
+    "link": "https://news.google.com/rss/articles/CBMickFVX3lxTE9iVUJsbmhIeDdrYjJlZDJOa0hHSXB4U3hSUk5WTmRXTmVZalhvZGx4QjFJMUtEUDV4QWsyNTZjSTdiRE54MGt0TlFoQm5NZDVpN0NhZkVmd1FBN0VBbk9PM0lJS3RXUVRLcmZ2OGxCOW1SUQ?oc=5",
+    "summary": "Salesforce Agentforce: What you need to know  MarTech Salesforce Agentforce: What you need to know  MarTech",
+    "published": "Fri, 25 Jul 2025 07:00:00 GMT",
+    "source": "Salesforce",
+    "category": "vendor",
+    "drawbacks": "Tableau dashboards require curation whereas ThoughtSpot enables ad-hoc natural language exploration.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Is Salesforce's 30% Upside Potential a Generational Buy Opportunity in the AI-Driven CRM Sector? - AInvest",
+    "link": "https://news.google.com/rss/articles/CBMitgFBVV95cUxNM2l5YkdEdjFzclEwdXp4Y3IxUlp5eXdsdXl0UkZsODhYeHphaWJ2MktOWVVzQkhfcUhrT0tWMzNWVjhOeERtRnM5YklnTUpFMTFGMXRwZW9iUk92R092OUxhUXR3V2RUUVJ5OHRkRHJZamFScGF0RTVRSmlQN3hCUXQyTDBmSE5IVTVXSnZTTi1jaVljVzItR25ac01ObHIxLU5mcU0xdVpUTWQzQ3U5VnhuZlowZw?oc=5",
+    "summary": "Is Salesforce's 30% Upside Potential a Generational Buy Opportunity in the AI-Driven CRM Sector?  AInvest Is Salesforce's 30% Upside Potential a Generational Buy Opportunity in the AI-Driven CRM Sector?  AInvest",
+    "published": "Sun, 03 Aug 2025 17:23:37 GMT",
+    "source": "Salesforce",
+    "category": "vendor",
+    "drawbacks": "Tableau dashboards require curation whereas ThoughtSpot enables ad-hoc natural language exploration.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Salesforce: The Generational Buying Opportunity Is Here (Rating Upgrade) (NYSE:CRM) - Seeking Alpha",
+    "link": "https://news.google.com/rss/articles/CBMiekFVX3lxTE9fazVsQVBqVTlOWlZ3ZXVuS00tZ01SOXlkOE56cEZtRUdNSXFucW5xS1I3RUdER012NTBXaFAzSExFZkpzb29BenQtLURmaks4RHdEajNzTjB1cVFWcC1xa0R3VGdhRlM3aEstV0ZaamRKSFBYWVU5aFhB?oc=5",
+    "summary": "Salesforce: The Generational Buying Opportunity Is Here (Rating Upgrade) (NYSE:CRM)  Seeking Alpha Salesforce: The Generational Buying Opportunity Is Here (Rating Upgrade) (NYSE:CRM)  Seeking Alpha",
+    "published": "Sun, 03 Aug 2025 17:10:15 GMT",
+    "source": "Salesforce",
+    "category": "vendor",
+    "drawbacks": "Tableau dashboards require curation whereas ThoughtSpot enables ad-hoc natural language exploration.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "The $196.6 Billion Agentic AI Revolution: Complete Market Analysis, Statistics & Growth Forecast 2025 - Australian Technology News",
+    "link": "https://news.google.com/rss/articles/CBMi1AFBVV95cUxQUTNmOUgwN1VSUlBYSHRSM3BoSVJjTHlndnR5QkdmTS1EcTl3akJSX3N2R3ZKY2ZtOTVscy1nTHY1RnpTY2tEUHk2OEplc05PS2FNMklVRndOMnZ0cm9jTVV3S0pfQWJRSWZuYXVIVFl6X2NnNzBkaU03VmI0N2VnczVsOVg0eEJoUktfQi16Ri15VkR0ZElta3lUdXpRQUlWcm04LTh1ak42Q2tWcGtkOXZiMXdWWmxXb2V0TFctRnZfUzFqaHZnLXVpNWtUcFg4YU5HUA?oc=5",
+    "summary": "The $196.6 Billion Agentic AI Revolution: Complete Market Analysis, Statistics & Growth Forecast 2025  Australian Technology News The $196.6 Billion Agentic AI Revolution: Complete Market Analysis, Statistics & Growth Forecast 2025  Australian Technology News",
+    "published": "Sat, 02 Aug 2025 03:05:18 GMT",
+    "source": "Agentic Analytics",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Momba launches agentic AI solution to transform business analysis and project delivery - AiThority",
+    "link": "https://news.google.com/rss/articles/CBMixAFBVV95cUxOeExheFhKXzBBZTBfYkFmRE9KV1RIUVdZR1hyV0VEZ21PWGFWRDB0TGRxVE9zcFR1aS1XTmtZNS1iTzdaWGdEb0dQX29DdjczLXRJV0h1S0ZrYUU0SXFOMU9uQ3pHLVBrbTRUVjBkZkIxMTMxdmM5Tmw1azZjRlJwWjBjMVJGblhtRGdJTVpHOFhFU3psRERvSTZ4QTNRNTlmX2VRYXlrWmdUb1pON2hsQzRiSzdoTXVUUm1fOGJsQ1hJNVh2?oc=5",
+    "summary": "Momba launches agentic AI solution to transform business analysis and project delivery  AiThority Momba launches agentic AI solution to transform business analysis and project delivery  AiThority",
+    "published": "Wed, 30 Jul 2025 15:09:20 GMT",
+    "source": "Agentic Analytics",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Qrvey 9.1 Accelerates Embedded Analytics With Agentic AI and a Faster Path to Deployment - Yahoo Finance",
+    "link": "https://news.google.com/rss/articles/CBMiggFBVV95cUxPc1d1RE9uYUdqeGpqeGFVMFNDR1oyM1hIM3lyNTd4UEZmWG51MkhLTTFWQ2JjZ2ZuYjE0bE1DTHBpQWMyb1hhVmRTRWVoZ2hKRVZFbXF1VFJheU4zcXlGazhzMGJidE0tWUJ4U1IxWlBDbjJFczk0T3MwT2xTNE5JNjRn?oc=5",
+    "summary": "Qrvey 9.1 Accelerates Embedded Analytics With Agentic AI and a Faster Path to Deployment  Yahoo Finance Qrvey 9.1 Accelerates Embedded Analytics With Agentic AI and a Faster Path to Deployment  Yahoo Finance",
+    "published": "Tue, 29 Jul 2025 12:00:00 GMT",
+    "source": "Agentic Analytics",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "AI-powered success—with more than 1,000 stories of customer transformation and innovation - Microsoft",
+    "link": "https://news.google.com/rss/articles/CBMi2wFBVV95cUxNME5hYTFnaE4wRmttRHFhVEw3ZW96NHV2UzR6bDkwdGpsNkJuMi1Tb2dkQTlNaG5yWHpndDBudVB3Rktscms2UmZnOEtJeHlFSXFGUTEyUm51aERaT0UxWmJ5cDdzNERQMkNIaFpwYXkzb0ZpZFFHY0hBMzlJNVVpeVE3Q216dFFVcUQwM1ZfLTkzcG1uandVYVRkcjR6NjdWMlZYZjE3Yl8zcUIwT2JxeGpfWjF2aGdLTG1rWDRlTDI1d1E1bThfTjlIMHVTTFJ5X1dKck1wR1FnVkU?oc=5",
+    "summary": "AI-powered success—with more than 1,000 stories of customer transformation and innovation  Microsoft AI-powered success—with more than 1,000 stories of customer transformation and innovation  Microsoft",
+    "published": "Thu, 24 Jul 2025 07:00:00 GMT",
+    "source": "Microsoft",
+    "category": "vendor",
+    "drawbacks": "Power BI and Copilot tie insights to predefined models, unlike ThoughtSpot's flexible search-first UX.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "What’s new in Power Apps: May 2025 Feature Update - Microsoft",
+    "link": "https://news.google.com/rss/articles/CBMisAFBVV95cUxQYkVoRWJkTldBV0pWVmZIZUdYeldNbnRVLWZabWtqdWlrS0MyN0FING9SanRkOEQyUTE2R0piMThVdHVwZmNCMmE0YzR5QUNGNS1lbVl2M2xpTWtkaTFqZkY0dExrU2luU2Q0aGc3X1g2RHZZNVN5dGhZeEptN2dqb05hRV80ZS1HbVdMMHlLVlcya3BXODFwVFNONWE5XzVqTWFXa0dvbURYVnZ5TmtLQw?oc=5",
+    "summary": "What’s new in Power Apps: May 2025 Feature Update  Microsoft What’s new in Power Apps: May 2025 Feature Update  Microsoft",
+    "published": "Mon, 09 Jun 2025 07:00:00 GMT",
+    "source": "Microsoft",
+    "category": "vendor",
+    "drawbacks": "Power BI and Copilot tie insights to predefined models, unlike ThoughtSpot's flexible search-first UX.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "What’s new in Power Apps: March 2025 Feature Update - Microsoft",
+    "link": "https://news.google.com/rss/articles/CBMiswFBVV95cUxQeWFZUllBam9sakxsamZ5TUdIVGlyY0dEUjFPVlFGRFRQSVltMTgxbEU1aWZ0Szd2NDRyY2Rza0JTWV85UnhBZmxIaDJvd3FIQnpmTnVrVnU4WGFFWFU3aW9WYnp1QWh4a0xNQ3pnYUVDU3haY012TVRaZjR4UElMcHNZZWVOMVBmVkRHVXhjd2p6cC1sWFdTY0hXSjVZLUY2dmo0RGQ3NlNaM1lhb3lQaHZVdw?oc=5",
+    "summary": "What’s new in Power Apps: March 2025 Feature Update  Microsoft What’s new in Power Apps: March 2025 Feature Update  Microsoft",
+    "published": "Fri, 04 Apr 2025 07:00:00 GMT",
+    "source": "Microsoft",
+    "category": "vendor",
+    "drawbacks": "Power BI and Copilot tie insights to predefined models, unlike ThoughtSpot's flexible search-first UX.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "What’s new in Power Apps: April 2025 Feature Update - Microsoft",
+    "link": "https://news.google.com/rss/articles/CBMiswFBVV95cUxPTHVDQzBIODNhdFM3bld2U1QyM2RhRXBiZE1uVE9xQnFXN2h6N3ZJNXVkc25vVUJOZHNicjFKRXNHbE02UFZuNW9DaVRhMzl6TFY5MVFQZS1Lcl9MUWk1MUdBdVlwNnZVQVM3cVRDQUVxblF6dGhPSVVWNHduMjBvZnpvN0szV0NPWGRfRkFmcTNRQ2M2Wnc5bS1VZEtzMXZ3bHdmYmNxR2tpby04T0lDU1JEMA?oc=5",
+    "summary": "What’s new in Power Apps: April 2025 Feature Update  Microsoft What’s new in Power Apps: April 2025 Feature Update  Microsoft",
+    "published": "Fri, 09 May 2025 07:00:00 GMT",
+    "source": "Microsoft",
+    "category": "vendor",
+    "drawbacks": "Power BI and Copilot tie insights to predefined models, unlike ThoughtSpot's flexible search-first UX.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Sessions you won’t want to miss at FabCon Vienna - Microsoft",
+    "link": "https://news.google.com/rss/articles/CBMiswFBVV95cUxNME9ScnpZMFVVaS1ZZ2pxZi1OOXByM1VEcjBVRXM2R0trVE9NV0VkVVFaTVhUVWVXazduNHZ2eURJR3Fha0lQX2xEcmlqUHM5akp3ejFubVZpLXhrdlNOTmdkZEdidXFHaHZKb2RDelc5cnVZclpRZXJRZ25MZFU2aHBCdFk2YnFaY0h6SnJ5d2RXVV9kQko1WHp0d0lqMDFGQTJzUXE0VHpHVktPVTFWN0l0bw?oc=5",
+    "summary": "Sessions you won’t want to miss at FabCon Vienna  Microsoft Sessions you won’t want to miss at FabCon Vienna  Microsoft",
+    "published": "Mon, 28 Jul 2025 15:00:00 GMT",
+    "source": "Microsoft",
+    "category": "vendor",
+    "drawbacks": "Power BI and Copilot tie insights to predefined models, unlike ThoughtSpot's flexible search-first UX.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "2025 release wave 2 plans for Microsoft Dynamics 365, Microsoft Power Platform, and Role-based Microsoft Copilot offerings - Microsoft",
+    "link": "https://news.google.com/rss/articles/CBMipAJBVV95cUxOcTZqSVpibWh5T0VyUXFlbF9RNkRjVVUzbkN1ZkIzeGYwSWQxbXNlMm9pZHhYTjA1VmZuSERleDRjdHphNktMd0diUzI3a3QtQTNwblhNa2JKM3E3N3F6RWxGRXZsQ3VXZ0FwbWhSU1haUUNSQkUyTnVrcGRmTEgzOWk2aGdoSHIyWnQxeWd2UE5FYUhodE5XVl96WEs1bDUyV2ppc0VMRlp0MVlTMFB6YnA3QVM2QjNxZnBXTUxUcXF6MG55T3dIVFNFU0pUZGdMMmlOR0hnRXJ6U1JabFlXLVdxRVlKdUF2RU9kU3RyVlZrUW45ei1hek9IMUR2SWFFMHRQbDcxLXV4QmlqTVJPUXhIenVZT25kV0N4VXliR3l4ZWpt?oc=5",
+    "summary": "2025 release wave 2 plans for Microsoft Dynamics 365, Microsoft Power Platform, and Role-based Microsoft Copilot offerings  Microsoft 2025 release wave 2 plans for Microsoft Dynamics 365, Microsoft Power Platform, and Role-based Microsoft Copilot offerings  Microsoft",
+    "published": "Wed, 16 Jul 2025 07:00:00 GMT",
+    "source": "Microsoft",
+    "category": "vendor",
+    "drawbacks": "Power BI and Copilot tie insights to predefined models, unlike ThoughtSpot's flexible search-first UX.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Powering the next AI frontier with Microsoft Fabric and the Azure data portfolio - Microsoft Azure",
+    "link": "https://news.google.com/rss/articles/CBMivAFBVV95cUxNWi0zQW1ucXYtQVV0dVRITjVEUUZSZDBvQkpBSFFVODlnSTZLSjBIdHVNZDBmOFdpcmVQUDlPUHZiODlxTklQUl9PeHp0ZnU5QzB4X1NHVmRaUWZ3NHQzRFg0Y0w5SWtQZXh0Wml6eklVSjZpLWx0MFlZMXNpTEhWeHRkS1ZVUjFKSGt2TkNmTEJYNUpfWHhpQW1Rb1FUVloyRXZhUHZqSFZJc3BnejVJTVdDckdZaEo5dDBKVg?oc=5",
+    "summary": "Powering the next AI frontier with Microsoft Fabric and the Azure data portfolio  Microsoft Azure Powering the next AI frontier with Microsoft Fabric and the Azure data portfolio  Microsoft Azure",
+    "published": "Mon, 19 May 2025 07:00:00 GMT",
+    "source": "Microsoft",
+    "category": "vendor",
+    "drawbacks": "Power BI and Copilot tie insights to predefined models, unlike ThoughtSpot's flexible search-first UX.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "PepsiCo Leverages Salesforce's Agentforce to Advance AI Agenda - PR Newswire",
+    "link": "https://news.google.com/rss/articles/CBMiuAFBVV95cUxQSFRvSjVtdEJQYkk5d2N4UndudzlyTEdrYllPSVU3UHBHSHpCLTlUUmRoSG51S19DcGJqbFV1TGc1Rkd6UHlEUlJHM09kZ3gzeXJjTTI4OTVEanVfcHBmcTdfQXluX3V3WkY2NUl2WmhTUlVFMXZBUl83cy1NT2VvUzRPbnZjLS1SWGdyZmZZa1FJSmJnZG9sMWN2YnZFRGEwck5BSEg3ZmR2OS1OSVdaM21WbjBTR3FI?oc=5",
+    "summary": "PepsiCo Leverages Salesforce's Agentforce to Advance AI Agenda  PR Newswire PepsiCo Leverages Salesforce's Agentforce to Advance AI Agenda  PR Newswire",
+    "published": "Tue, 24 Jun 2025 07:00:00 GMT",
+    "source": "Salesforce",
+    "category": "vendor",
+    "drawbacks": "Tableau dashboards require curation whereas ThoughtSpot enables ad-hoc natural language exploration.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Salesforce Bets Big on Agentforce: Can AI Agents Power Growth? - Yahoo Finance",
+    "link": "https://news.google.com/rss/articles/CBMihgFBVV95cUxPTHloLVBxZWUwTXNBT21MajAxSmNVSi13SVEzaWNjbHNHYm84YjBJbExZSHYydGgxeVlEQTVCT0dzX2FBQm1LcXJFR2FvdndaSTg2NHhIUjhsWE1KOE81UHZaZjVKanJleUNsTFpjX055d0VLd3JzdFZ2QTdqRzdjOUFWOGZyZw?oc=5",
+    "summary": "Salesforce Bets Big on Agentforce: Can AI Agents Power Growth?  Yahoo Finance Salesforce Bets Big on Agentforce: Can AI Agents Power Growth?  Yahoo Finance",
+    "published": "Thu, 17 Jul 2025 07:00:00 GMT",
+    "source": "Salesforce",
+    "category": "vendor",
+    "drawbacks": "Tableau dashboards require curation whereas ThoughtSpot enables ad-hoc natural language exploration.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Salesforce Agentforce 3 promises new ways to monitor and manage AI agents - cio.com",
+    "link": "https://news.google.com/rss/articles/CBMitAFBVV95cUxPdk5CX2hreVhjazRpVGlvSlNkczRFcW5zUVBvSEJQeUNrbUVWVl9qb1BQTjUxejZqWm02YzRVWHl2TENxVUpkR0NsV3hyRFFNVElBNkZrU1IzVjI2WjBGRzNnMWJSLVhCbHB4ay1zQS1GOUFaSGUwX0Q4dnVzWlZ6aDRZaUlYbkgteTBJN2Vac0x2ZkFKZEJXT0NWR0xLdVAweFdEUEhycEtWZ053VFUxTlFScFY?oc=5",
+    "summary": "Salesforce Agentforce 3 promises new ways to monitor and manage AI agents  cio.com Salesforce Agentforce 3 promises new ways to monitor and manage AI agents  cio.com",
+    "published": "Tue, 24 Jun 2025 07:00:00 GMT",
+    "source": "Salesforce",
+    "category": "vendor",
+    "drawbacks": "Tableau dashboards require curation whereas ThoughtSpot enables ad-hoc natural language exploration.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Unlock Actionable Insights from Unstructured Data with Cortex AI - snowflake.com",
+    "link": "https://news.google.com/rss/articles/CBMiyAFBVV95cUxOY3IzYUtieElPTlRlZjRDWE5sdkkyNGZxVm80eWJZYjZWUklaRXVJcE5KcGNKNnJvUjFYTk9UbTlYX2FSZm1pcVB5Skh2NU80cWxMMVROUEdiQ0tpY2hlbUl0UEFud2RMbTBMRXZieWJBUVNSZHIxZjRIcy1xc1RUUmhxdHZsSkV5V1p6eUUwQ3p3UVFsRGFSb0RJWVp0TzZQdVpiUjdTRG1LanRNRXhSNE9HYTFFc2RjdnFqNGs1bWQyTDFBV2s3UQ?oc=5",
+    "summary": "Unlock Actionable Insights from Unstructured Data with Cortex AI  snowflake.com Unlock Actionable Insights from Unstructured Data with Cortex AI  snowflake.com",
+    "published": "Wed, 23 Jul 2025 21:17:18 GMT",
+    "source": "Snowflake",
+    "category": "vendor",
+    "drawbacks": "Snowflake Cortex targets developers and misses ThoughtSpot's easy natural language queries.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "StackAdapt unveils Snowflake native app for first-party data activation - PPC Land",
+    "link": "https://news.google.com/rss/articles/CBMikwFBVV95cUxNaXY4dHM1ME9tRUhTbThtLTB1M2pXT2tSNjV5NWZ2VFp5RVM4Q2ZLYjVlbFhIZTIzZmZ5MmhqOE91bnBiX2xvV0Q1MTlQem0yZlhoZDdCazRNTlVuQ2xfTnlPUWE4R0RBZmFYaElteXBDbVhZTkhLT040QUMxRTc0TzFzU3U2Rjl2VG1hWHNRYTVnR28?oc=5",
+    "summary": "StackAdapt unveils Snowflake native app for first-party data activation  PPC Land StackAdapt unveils Snowflake native app for first-party data activation  PPC Land",
+    "published": "Tue, 29 Jul 2025 20:26:28 GMT",
+    "source": "Snowflake",
+    "category": "vendor",
+    "drawbacks": "Snowflake Cortex targets developers and misses ThoughtSpot's easy natural language queries.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "StackAdapt Unveils Snowflake Native App, Powered by Snowflake Cortex AI, Unlocking First-Party Data Activation and Insight for Programmatic Campaigns - Business Wire",
+    "link": "https://news.google.com/rss/articles/CBMirAJBVV95cUxNQWZTajRFY1B2c3JjbmxxVmoxM2FuVUpyWnowRHZUWTJIM0gzd0VlMzNIZDlJTFdoS2NWUVpEUE96dXNDZDJwUHdpY3I0Ykk0MFUyV2F6OEtpa2lKako4MUZKWnZSeFMySTVIYmtfWjJ0Tzd5ZUZZX1dvam9ZVnNNNFg2UUdNSFBROVk4TnZ6VGZVSHBTSTZqMWMwSVFRM1hPeHFfWnlmWEFKQlhraHF5VnRic3daR0x2N1dpTmNOM1owTmQxQlhDbkNTS3ZLdXFxcnpCbnVFazRpLXh4OVhUcDYza04wek56RFd1WDk2dTR6aXpOQ3dqaXdZUmhyVnotZXJTdFdEM0dfd0xFUmhGNGFCYUNhZFFBbmdxQnFxM0VNbEdWZ2Y1Vm5VX2c?oc=5",
+    "summary": "StackAdapt Unveils Snowflake Native App, Powered by Snowflake Cortex AI, Unlocking First-Party Data Activation and Insight for Programmatic Campaigns  Business Wire StackAdapt Unveils Snowflake Native App, Powered by Snowflake Cortex AI, Unlocking First-Party Data Activation and Insight for Programmatic Campaigns  Business Wire",
+    "published": "Thu, 24 Jul 2025 07:00:00 GMT",
+    "source": "Snowflake",
+    "category": "vendor",
+    "drawbacks": "Snowflake Cortex targets developers and misses ThoughtSpot's easy natural language queries.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "GrowthLoop Compound Marketing Engine Now Powered by Snowflake Cortex AI - PR Newswire",
+    "link": "https://news.google.com/rss/articles/CBMixgFBVV95cUxPaFppdV9ndnJxenRQb0pFMExHM0pyT09hb1J0TGY1OWJPTHVBU1JyQ2tCMnJTSVN2dG94bU95b0xNa3g5Zk04UWhwd001LUhHT3pZbFUyVmNnQ0JEeGl3TmJyZmhjbVVyc2xuQXdpU3dpOVNDRGE1dVlzVFI0bjFsN3ZaS3UzMmFtVTVnODJwWTFIS1BBQ1U4Y2NQeDhqdUF2NGdvclUzSFkxR1d5NkFuelRjQXRaaUFmVm5tbzdVRUN4elFRUmc?oc=5",
+    "summary": "GrowthLoop Compound Marketing Engine Now Powered by Snowflake Cortex AI  PR Newswire GrowthLoop Compound Marketing Engine Now Powered by Snowflake Cortex AI  PR Newswire",
+    "published": "Tue, 03 Jun 2025 07:00:00 GMT",
+    "source": "Snowflake",
+    "category": "vendor",
+    "drawbacks": "Snowflake Cortex targets developers and misses ThoughtSpot's easy natural language queries.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Snowflake’s Cortex AISQL aims to simplify unstructured data analysis - InfoWorld",
+    "link": "https://news.google.com/rss/articles/CBMitAFBVV95cUxQY3c3M3JZeFpwV29QTXdWOTJzcEp2V1lvcDk3TEhPdTBIajNfa2M0TE5val9oMTVTS2Ffb1VrQ192WUJIQlhDTzMtT2Y3UF9LZHJtYWVmQWpFTDZ5aE1uaTdDazdtLVhkVld5aTUxMVRpMUJlTHhmc2lBbDR0WUxpYmJJdzBQSUE5RTZ1ODctUk93aS1SemxnSkZHRUpraTVuNk5pSG9nMVJ4endtZHhrVGpGUHI?oc=5",
+    "summary": "Snowflake’s Cortex AISQL aims to simplify unstructured data analysis  InfoWorld Snowflake’s Cortex AISQL aims to simplify unstructured data analysis  InfoWorld",
+    "published": "Tue, 03 Jun 2025 07:00:00 GMT",
+    "source": "Snowflake",
+    "category": "vendor",
+    "drawbacks": "Snowflake Cortex targets developers and misses ThoughtSpot's easy natural language queries.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Databricks Unveils Databricks One: A New Experience to Bring Data and AI to Every Corner of the Business - PR Newswire",
+    "link": "https://news.google.com/rss/articles/CBMi9AFBVV95cUxPS2VNaWdId3VvOTF6TWVVczhOQ3NVdHNmYzdLVU1mUThfbDVNdnFIcXAxY0pwUlJtSzl4Qy1LXzFab3dFVmtKcTJ3Sm9HZ0YtSC1WMjI2MDg1ZTVYTzJpSXMyQ1FhWXByMW1fVjdnZk1USmJLZVN2UDNZYy1QLVpHcGdseFpsWGJfMTNWU1VXZXpvcVlCOHVDZGk4TkNISm9tX2psZ0lkTnNTVXdQUF83QXBKZlZOVmlDTV83N19XNjY2TjZValF0bXZUbzJwV2k0OXhwRTBGNkRXUkhNMnR4ZllkeTFwNlJSNjJRVVRBLVZEY2Jf?oc=5",
+    "summary": "Databricks Unveils Databricks One: A New Experience to Bring Data and AI to Every Corner of the Business  PR Newswire Databricks Unveils Databricks One: A New Experience to Bring Data and AI to Every Corner of the Business  PR Newswire",
+    "published": "Wed, 11 Jun 2025 07:00:00 GMT",
+    "source": "Databricks",
+    "category": "vendor",
+    "drawbacks": "Databricks Genie emphasizes data engineering but lacks ThoughtSpot's live search-driven analytics.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Upskill your team on Azure Databricks with an on-demand webinar and Microsoft Learn - Microsoft Azure",
+    "link": "https://news.google.com/rss/articles/CBMiwAFBVV95cUxQMlg1V3FocmdEWEIwOW9KeTJTMVJHaUxHbFVNZWNXM0tFd0ROMUFMV09adDh1d0l1SmpEQTQ1aXB6RUJSZVZUbVhhWnFuWGZTa25jWDJNVDBwOU9rQUg5Y1FEZ05RN1RzSUsyMzRwMHNTMDN1XzNjcDNvQVpXLWNrTTNGUlA5MHR5QllMWnAwdGNrSVRCVF9nNG1LdWdVZUZ6RTdPc2JyRzhXbnR4MHBncWNTQ3dCc3VjWk56LUlzOWs?oc=5",
+    "summary": "Upskill your team on Azure Databricks with an on-demand webinar and Microsoft Learn  Microsoft Azure Upskill your team on Azure Databricks with an on-demand webinar and Microsoft Learn  Microsoft Azure",
+    "published": "Thu, 17 Apr 2025 07:00:00 GMT",
+    "source": "Databricks",
+    "category": "vendor",
+    "drawbacks": "Databricks Genie emphasizes data engineering but lacks ThoughtSpot's live search-driven analytics.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "AtScale Powers Databricks Genie with Semantic Layer Delivering Accurate and Trusted Natural Language Querying - Business Wire",
+    "link": "https://news.google.com/rss/articles/CBMi-gFBVV95cUxPSFlZb2xEV29UMTlrMzJEdVA4cnNWM280bDhUMW40TThBQWNXdDZBaWViTFkwOXBCX0VkTHpqaWtyM0F2TTc5dFRTWUtwN1FLS2M4SGZJQzRtWE1NdlVqU3c1eTlqZzVoQm5fTk9lclVrRmdLRzEwNXF6Y3FXZVRxT18zaTJGMm9oQ2tsX1ZqbGVrWGxGYlZpZ21KWGFsLXZ3eTREdm4wd1FscTc1cTN1TG5QMmJNZlpNbWZITHI4blBoTEdkX211em5xWGlYMW45SDljckpwVm9sQUZnVHVRQUo0SnYtam9wYXpNV0dONUpNWTRBNHNLbm9n?oc=5",
+    "summary": "AtScale Powers Databricks Genie with Semantic Layer Delivering Accurate and Trusted Natural Language Querying  Business Wire AtScale Powers Databricks Genie with Semantic Layer Delivering Accurate and Trusted Natural Language Querying  Business Wire",
+    "published": "Mon, 10 Mar 2025 07:00:00 GMT",
+    "source": "Databricks",
+    "category": "vendor",
+    "drawbacks": "Databricks Genie emphasizes data engineering but lacks ThoughtSpot's live search-driven analytics.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Databricks One brings data and AI to the entire organization - Techzine Global",
+    "link": "https://news.google.com/rss/articles/CBMiqwFBVV95cUxPb1pjRVZFYXRjdzBJYmd3dmUxSVJCTVFtRjRzd0lrQTNvd3l1WkgzalZaSWlBZ1NrQlF0RnBRMlNCRFhBdm9tWVRDRXZQVF9yay0tbUVSRmROa1ZkLUp1M1Utb0ZBTUhieUJsR05nNWZybTVWeUMxRl9mSVlLdVBXZ2IxRUF4bjZ4aW9wNXR5MFg4eEphQWpQcXZpN0Z4LWpCU3pHcFpkUEhPRjA?oc=5",
+    "summary": "Databricks One brings data and AI to the entire organization  Techzine Global Databricks One brings data and AI to the entire organization  Techzine Global",
+    "published": "Thu, 12 Jun 2025 07:00:00 GMT",
+    "source": "Databricks",
+    "category": "vendor",
+    "drawbacks": "Databricks Genie emphasizes data engineering but lacks ThoughtSpot's live search-driven analytics.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Databricks kicks off an initiative to make AI agents easier to build and manage - SiliconANGLE",
+    "link": "https://news.google.com/rss/articles/CBMipgFBVV95cUxPbHJ4OW5ZNEdxc1BFRzUtcHBrMG1vLU9YOENZSXVNZXJnbjR2cy1DSUFIZnpwZVhKNkFqaEtxMTNielVnUzM2aWdqdENaM0doYkU4eWZ5MDU1eS1CU0Y0M0hGWEJXaDdFUmtGZHUtQVlfUzA2cGt4OEYyemltVEd4T01kRWxWejRTRzcxdkFuMWlhNEs5SjFuSnBOajB2ZXJNMmVSZWJB?oc=5",
+    "summary": "Databricks kicks off an initiative to make AI agents easier to build and manage  SiliconANGLE Databricks kicks off an initiative to make AI agents easier to build and manage  SiliconANGLE",
+    "published": "Mon, 10 Mar 2025 07:00:00 GMT",
+    "source": "Databricks",
+    "category": "vendor",
+    "drawbacks": "Databricks Genie emphasizes data engineering but lacks ThoughtSpot's live search-driven analytics.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Hydronorth boosts efficiency and decision-making with Qlik’s data platform - Intelligent CIO",
+    "link": "https://news.google.com/rss/articles/CBMivwFBVV95cUxNbTlqOXB6anN5T0JTbmhldWR4MUVhVWs0ejJkU3B4VDNyWmloOHN2YVJGV1dmTzJNWUd3ZGpwOFE5MUZwbmctbllSU2pjMlBIUVMzYTF5YW9BVFZUVXJDMnBuX2xSTnpGSTNjWmtTaEw4N3BBUzgteXRIMUdYZTdwUE9UaWpxUS0zeGRQc1lBV3FXSmpWS3FuY2tTbzBBNjZ4cFAzQ2hJSWl2ZHVjTGVLeGxKdWpmWXdtR1pNT2YzMA?oc=5",
+    "summary": "Hydronorth boosts efficiency and decision-making with Qlik’s data platform  Intelligent CIO Hydronorth boosts efficiency and decision-making with Qlik’s data platform  Intelligent CIO",
+    "published": "Fri, 01 Aug 2025 12:40:50 GMT",
+    "source": "Qlik",
+    "category": "vendor",
+    "drawbacks": "Qlik's script-heavy approach complicates setup compared to ThoughtSpot's intuitive search.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Logistics Plus Outpaces Larger Rivals with AI-Powered Supply Chain Intelligence from Qlik - Business Wire",
+    "link": "https://news.google.com/rss/articles/CBMi3wFBVV95cUxNbjRQSUo4NjZLRENKd3pTTTNYQllPQm5qbHhvMGNLVWpuLWlOZ2FMQ0pFOFZKSGNSVU1BTTBVRmxkZ2tDaHhQUWs5aFVWdkM5dHNYSDA5T3hlSktGemw1LUhhRENQWmktZi16emJFQk1pMGt0eE0yMnVKYzFqQXMxRGxhZ0pWcU1meld1bUFETXFNdUZZa2VIcWpmUU16RlQ3TFRFOG8ycTI5UkNKOWM3bDJLOU9qRFA5bnFwWVBRbUtxNVR4SWxwNmU5MlNTb0xxVWVPbWtRbFdURnpHVTZz?oc=5",
+    "summary": "Logistics Plus Outpaces Larger Rivals with AI-Powered Supply Chain Intelligence from Qlik  Business Wire Logistics Plus Outpaces Larger Rivals with AI-Powered Supply Chain Intelligence from Qlik  Business Wire",
+    "published": "Tue, 29 Jul 2025 12:30:00 GMT",
+    "source": "Qlik",
+    "category": "vendor",
+    "drawbacks": "Qlik's script-heavy approach complicates setup compared to ThoughtSpot's intuitive search.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Nissin Foods taps Qlik for real-time ERP data and analysis - Frontier Enterprise",
+    "link": "https://news.google.com/rss/articles/CBMimwFBVV95cUxPLXNqdlctT3J4S29UWlRmMVdVSFBaZmN6LUhObnFaMzNmVjEtM1d4NXlscnFsdFg0TTF6cUVIQUFOcDRsT3lNUEVJMFZVNDFWUWIwS2FFaWhBcVozMG80eFZOWktoZWxlX3AwSGtjYWU5TVdQV3RDUmRlbHl2NFZTM0lKSnQ3VTVHTnJ4cFYzOFdTcjRzeEViWFhsOA?oc=5",
+    "summary": "Nissin Foods taps Qlik for real-time ERP data and analysis  Frontier Enterprise Nissin Foods taps Qlik for real-time ERP data and analysis  Frontier Enterprise",
+    "published": "Thu, 31 Jul 2025 03:00:00 GMT",
+    "source": "Qlik",
+    "category": "vendor",
+    "drawbacks": "Qlik's script-heavy approach complicates setup compared to ThoughtSpot's intuitive search.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Qlik Launches Cloud Data Lakehouse, AI Agentic Capabilities - CRN Magazine",
+    "link": "https://news.google.com/rss/articles/CBMilgFBVV95cUxOTk56RGsteXAzVTVoLThEVVdFMzU1emwzRlF5RDNHZWVWd3ZwWVJvaXlEX1FpaDBxYnNfTnBlRThWRUpnQVpXMEdzTlBidTBBSFhGcmJPZ2ZKcnZ5dXRoN1k2bFdmS2VycjRqNkhSSUc5NVlVYms4UkhEUHFrOUtVQUdBZ1dnbThndzg2YlFlQXF3VXRnbWc?oc=5",
+    "summary": "Qlik Launches Cloud Data Lakehouse, AI Agentic Capabilities  CRN Magazine Qlik Launches Cloud Data Lakehouse, AI Agentic Capabilities  CRN Magazine",
+    "published": "Fri, 16 May 2025 07:00:00 GMT",
+    "source": "Qlik",
+    "category": "vendor",
+    "drawbacks": "Qlik's script-heavy approach complicates setup compared to ThoughtSpot's intuitive search.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Analytics and Data Science News for the Week of May 16; Updates from Alteryx, Databricks, Qlik & More - solutionsreview.com",
+    "link": "https://news.google.com/rss/articles/CBMi4AFBVV95cUxNeXRpZURWZVd1bERPdEVtSkFRdnhKUl9qejdpNFdaSGJxOHZ2d2ktSXBjTmlScnRxM0g1eW9HWmFHRUtYWGttYS1NYW9sYWd1VnBvOWVjY2hiOFFTSEFrX204T1M4TGE4RTh6V0RxZ1lyaGNCSzhJZHJuRXYzZllxVUY3WnBYUlZXZmUyUFlOZzhJdlM0QnNRTzMwcEdxd29Pa2I4eTZ3YWxuVGFvaFFmb1ZTSnJqcVktS0Zlc0drR1VlVEUzeHpzSUt0Mnh5SEhFY3ZkWkVpZTRLVDZmaTlHQQ?oc=5",
+    "summary": "Analytics and Data Science News for the Week of May 16; Updates from Alteryx, Databricks, Qlik & More  solutionsreview.com Analytics and Data Science News for the Week of May 16; Updates from Alteryx, Databricks, Qlik & More  solutionsreview.com",
+    "published": "Fri, 16 May 2025 07:00:00 GMT",
+    "source": "Qlik",
+    "category": "vendor",
+    "drawbacks": "Qlik's script-heavy approach complicates setup compared to ThoughtSpot's intuitive search.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Looker Studio introduces Code Interpreter for advanced data analysis - PPC Land",
+    "link": "https://news.google.com/rss/articles/CBMijwFBVV95cUxQMkZjOGswTUsyMEdoSlE2bXVhSlI3NkZwM1pnZXZfOTBySDU4TzVPZWIwY29GT1BYNFJwMWtiWk93WDdoUkkxLXZQdUhuQzkxYUdDWEVIUUZmem9KSDRxNkRxX0M2VTVWU2poMXd0ZG05MzFGcGV2ZlFZLUtqWmREeXpzSTBSd3ZFYWxXLVlGNA?oc=5",
+    "summary": "Looker Studio introduces Code Interpreter for advanced data analysis  PPC Land Looker Studio introduces Code Interpreter for advanced data analysis  PPC Land",
+    "published": "Tue, 29 Jul 2025 05:33:01 GMT",
+    "source": "Google",
+    "category": "vendor",
+    "drawbacks": "Google's BI stack is less search-centric than ThoughtSpot's AI-driven analytics.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "My Experience Switching From Power BI to Looker (as a Senior Data Analyst) - Towards Data Science",
+    "link": "https://news.google.com/rss/articles/CBMiuAFBVV95cUxOeFJ0TElWbTQ1VUZIRWtqaDlLQ09rbXpEd1c5YUNoRUtDRmdzNndDOGRNTGYtenphOURGMUFuYWNZQzhkcXJZYnhDbjJUZzZTd0NpOVJNNGFaRVBaNlJzNnpId3dGUExIN1RpdXpzSm0wcFFOOXVmemlwVDkzQ0swZndUem82X3ZfT2ROSHpVQW04Y3NuNlFOUWg4SlZVOE5qS2NKQTdyc3RJWHNlVS1LYjJxZDJUS1dB?oc=5",
+    "summary": "My Experience Switching From Power BI to Looker (as a Senior Data Analyst)  Towards Data Science My Experience Switching From Power BI to Looker (as a Senior Data Analyst)  Towards Data Science",
+    "published": "Fri, 17 Jan 2025 08:00:00 GMT",
+    "source": "Google",
+    "category": "vendor",
+    "drawbacks": "Google's BI stack is less search-centric than ThoughtSpot's AI-driven analytics.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Google lets AI agents do the data work in BigQuery and Looker - Techzine Global",
+    "link": "https://news.google.com/rss/articles/CBMirAFBVV95cUxNWHptb0NtcF9rZ2xuT05TZ0NfYkQ4OG4tcGZTb2VBNW1TUkpWNm15LTU1MG9VUXFxT21zcGFOMjhySzRSOUxtbThES1FCZF92U2xBTVhYVGdGWkR6S0MwYXJ6NTdES01XMUtkb29nS2pTY3RKVmJES3o2Qk5oVG9Wb1V0NGlvQmpKSEFYS3NWWmlFb3R4VU0zM2ZnbFg3RUJVelJEc3ZaWWhUNHR0?oc=5",
+    "summary": "Google lets AI agents do the data work in BigQuery and Looker  Techzine Global Google lets AI agents do the data work in BigQuery and Looker  Techzine Global",
+    "published": "Wed, 09 Apr 2025 07:00:00 GMT",
+    "source": "Google",
+    "category": "vendor",
+    "drawbacks": "Google's BI stack is less search-centric than ThoughtSpot's AI-driven analytics.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Google’s BigQuery and Looker get agents to simplify analytics tasks - InfoWorld",
+    "link": "https://news.google.com/rss/articles/CBMiswFBVV95cUxQSU9Jd1pKMTdXU3BBd2RjWUs3Mlhta2w3enI1Wlp0dENyWWxZdVk0SXNGMTFzdHZRZ3ZKUU9SUTBtR3NKX0h1MnE3MnUtVmdYZ3NrblQ0aGhXVXkyM3VTYURUZW1EbEFVYVFEa2Q2cTRsaEpDM2drUnpxOTQ3RnJITklBdlJLS2JOWlNTM2lnZGpIZzNHQlUySUgxM3RtRTZLZjE0VGJra2tEQ1hsSklqSnc0SQ?oc=5",
+    "summary": "Google’s BigQuery and Looker get agents to simplify analytics tasks  InfoWorld Google’s BigQuery and Looker get agents to simplify analytics tasks  InfoWorld",
+    "published": "Thu, 10 Apr 2025 07:00:00 GMT",
+    "source": "Google",
+    "category": "vendor",
+    "drawbacks": "Google's BI stack is less search-centric than ThoughtSpot's AI-driven analytics.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Fig. 1. Visualizations from the SARS-CoV-2 Dashboard in Google Looker... - researchgate.net",
+    "link": "https://news.google.com/rss/articles/CBMizwFBVV95cUxOdkx2ZnYwYVlpU1hEcXF2T25mZlFfS1JBeXdHWng2OEtGSndNcnRRTGQyZTI4WEtmS0xWQzdHaW0wbFl6NEZuZkJuZXdTVG96WnNNZW1MRWJxY1cxUzFLNk54d2ZBNEkwOEhoQnlvNWRwcTRkVU1EM0dVWDI5dTBrN1dpaFZ3NEhVblJFLU9ZUjhDVGlVZU5GT3FxSGJmZndwejFSczNmTDBDOVA5SW1MSXpVVy1FeUphRk5tSWNvQkVOVDgxMGdpSzBVelBLQTA?oc=5",
+    "summary": "Fig. 1.",
+    "published": "Thu, 17 Jul 2025 05:54:51 GMT",
+    "source": "Google",
+    "category": "vendor",
+    "drawbacks": "Google's BI stack is less search-centric than ThoughtSpot's AI-driven analytics.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Try Deep Think in the Gemini app - The Keyword",
+    "link": "https://news.google.com/rss/articles/CBMiakFVX3lxTE84QWt6azVIbFRwVGpFbXdzSFdsakgxamdmZS15NWxmU1luVjlMUHp6WV9oRVhJa1dMRFJHcTlFRFNvM3dKUGZkNF9fZ0x5T2RJQmFQOXJhOWI3bmZDXzZnb29xaVJIQ0VmaFE?oc=5",
+    "summary": "Try Deep Think in the Gemini app  The Keyword Try Deep Think in the Gemini app  The Keyword",
+    "published": "Fri, 01 Aug 2025 13:27:45 GMT",
+    "source": "Google",
+    "category": "vendor",
+    "drawbacks": "Google's BI stack is less search-centric than ThoughtSpot's AI-driven analytics.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Google renames most of its new Gemini-Assistant voices for Nest [Video] - 9to5Google",
+    "link": "https://news.google.com/rss/articles/CBMifkFVX3lxTE9veW8zSGE1NzBJSDVUeXRndi1QbU1pUUpFVmYxZUh5RjNLN29zWDZBQmxocHpXOVlteEt5MWg5S050VnByX2owZk9HZTd3enJGOHRvMnVEZHFzRnJjN25oNktRSzl2Zmt5dXJwaEJpU0hsTjJSMG9BYnBzb1BGUQ?oc=5",
+    "summary": "Google renames most of its new Gemini-Assistant voices for Nest [Video]  9to5Google Google renames most of its new Gemini-Assistant voices for Nest [Video]  9to5Google",
+    "published": "Sat, 02 Aug 2025 19:05:00 GMT",
+    "source": "Google",
+    "category": "vendor",
+    "drawbacks": "Google's BI stack is less search-centric than ThoughtSpot's AI-driven analytics.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Google releases Gemini 2.5 Deep Think for AI Ultra subscribers - Ars Technica",
+    "link": "https://news.google.com/rss/articles/CBMinwFBVV95cUxNUGltRk0zdTdQeFhZOUNrM3RfUy01bTdtTzRFOE1kRnZBSWt3N185SkJUdEE0RHJvWmhzejBOWFlWdGh3MWhLLW9fU1MyeXo4S3BrMHdEdmFfSFNtUlllYmlKMFJDU0F1aTZiTTl5VWVIZlpCWkM1WmRLNmRqSUJ1ZXpUYWJueGoxamsyU3Q4RG5FLW96Mi1SNDdhdExIYUk?oc=5",
+    "summary": "Google releases Gemini 2.5 Deep Think for AI Ultra subscribers  Ars Technica Google releases Gemini 2.5 Deep Think for AI Ultra subscribers  Ars Technica",
+    "published": "Fri, 01 Aug 2025 15:36:08 GMT",
+    "source": "Google",
+    "category": "vendor",
+    "drawbacks": "Google's BI stack is less search-centric than ThoughtSpot's AI-driven analytics.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Google rolls out Gemini Deep Think AI, a reasoning model that tests multiple ideas in parallel - TechCrunch",
+    "link": "https://news.google.com/rss/articles/CBMixwFBVV95cUxOUzRFWHA1QUZPeWhISThpRlNTRk9sWjNIQzlmLUpsZWp0azBEWTlhdkN2TzNndGZCWjg3QWJQSHptMTR2QkVlSF8wTjY4MjV2Wmo1T2lubU1URWNaSHhwQUlXdXFPc0t1SnltSU91S0dPVXdBcGhVVi02MF8xNUFNSWtiTVd4WWt1TFN1am5UT0hmZkE1NUtRUkw3Tnd0bHl5Q3RGSF9xWlFvU0t6cEtXQVhEWUJnX1JmSWlNaXc3RHRCWE81cFVZ?oc=5",
+    "summary": "Google rolls out Gemini Deep Think AI, a reasoning model that tests multiple ideas in parallel  TechCrunch Google rolls out Gemini Deep Think AI, a reasoning model that tests multiple ideas in parallel  TechCrunch",
+    "published": "Fri, 01 Aug 2025 11:00:00 GMT",
+    "source": "Google",
+    "category": "vendor",
+    "drawbacks": "Google's BI stack is less search-centric than ThoughtSpot's AI-driven analytics.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Using ChatGPT or other AI tools? Here’s who can see your chat history - Fast Company",
+    "link": "https://news.google.com/rss/articles/CBMipwFBVV95cUxPOXlmY3BjWU1mNWVVVzNzZU15empRcXd2RE0tb0k5ejRJTUxNODhCcnZfLW1MTGJqVS10MWtfc2FfYWdVb0s5NnlEOVZrVzVJdnJGeTM4cWhXUlFYTGNGdjdSU1RPNV9qOGJ3VzcyUmZiV3UzYy1yMzhqM2FuUVhXMzlTMDhwbngzVmUxcHF1VnYxN1lHa2dZQzFPWHQ5cExWRGRrdHd6WQ?oc=5",
+    "summary": "Using ChatGPT or other AI tools? Here’s who can see your chat history  Fast Company Using ChatGPT or other AI tools?",
+    "published": "Mon, 04 Aug 2025 10:12:28 GMT",
+    "source": "Google",
+    "category": "vendor",
+    "drawbacks": "Google's BI stack is less search-centric than ThoughtSpot's AI-driven analytics.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Agentic AI could be the Breakthrough Indian SMBs were Waiting For - sify.com",
+    "link": "https://news.google.com/rss/articles/CBMiogFBVV95cUxQbGcwMkV4RnUtcVgwTDJ1NXd6RHFYV180Q0U0enVKRjlLOF9obk9uQkFQcnllMW9DWWFVLVlvcDFUb25iRDdFVF9Nc0lMdzktUV9WdmZRRk5adGxVZEFzbjZLMkJidnJXY3lDdHZwS2RTcTNxMm82cE9BYm1tQzEwVTRvRHQtMDlWMHRYZlFqc1NLRHJVMG91SVVsSVczY0loblE?oc=5",
+    "summary": "Agentic AI could be the Breakthrough Indian SMBs were Waiting For  sify.com Agentic AI could be the Breakthrough Indian SMBs were Waiting For  sify.com",
+    "published": "Mon, 04 Aug 2025 05:17:12 GMT",
+    "source": "Agentic Analytics",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Driving Business Value With Agentic AI - hbr.org",
+    "link": "https://news.google.com/rss/articles/CBMifEFVX3lxTFBBOWtyNmdRMGpPMWlyNXBMaGNLLWhncm51cS12SWFZZzNvU2UzaEdmbExPbGlFTU45ZVl4bXlRczQxbEpxUWVPYVJIaFZpRGRQWkNGS1IyTTM4cVlYcTlZN0NqZ1BraXQyNjU0bzVsd3JRT0V4QllxdE5ta1Q?oc=5",
+    "summary": "Driving Business Value With Agentic AI  hbr.org Driving Business Value With Agentic AI  hbr.org",
+    "published": "Wed, 16 Jul 2025 07:00:00 GMT",
+    "source": "Agentic Analytics",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Pamplin students leverage data analytics to improve the undergraduate experience - Virginia Tech News",
+    "link": "https://news.google.com/rss/articles/CBMihgFBVV95cUxQTHpCWlB2anVybmdfNExhblVVLWsxYXk2Y080SzRfWGszWXRGTXZQeDZHXzRVTW9Ga1ZkNlZDSVN3NkF0ZFZpR2lDaVRNMmlwaHgxVGV6V3lzd0VJZ3hoaHFvMFlVWHlSdU1pOFBVSVM3cUdsVzdaVDJwanJvdlU2TVFRRzZqZw?oc=5",
+    "summary": "Pamplin students leverage data analytics to improve the undergraduate experience  Virginia Tech News Pamplin students leverage data analytics to improve the undergraduate experience  Virginia Tech News",
+    "published": "Mon, 04 Aug 2025 14:26:14 GMT",
+    "source": "Data Analytics",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "6 U.S. cities will get data analytics, AI support via international alliance - Smart Cities Dive",
+    "link": "https://news.google.com/rss/articles/CBMiuAFBVV95cUxOU2daT1RCTEl1Vl9zN2I0Uzg1em5ITXJLT0ZWZk0wWW55dWE4cUNIUHFMMGdteXN3WjJTSEJlbW4ydnRLaGhIOWdhSnBJTlNlY2M5dXdpUlVpY0JZemE5MHZyMjNiYS1aSmJqbHpLa0UxTG9UemJsaHc3MG5HMFB1dzZqSWFoalR2enNNVE1sc2lmVXVxNnpodWYzTXZEYUJrbThSd0l1U0pOQl9zUDEyY2VuMFlZQXhu?oc=5",
+    "summary": "6 U.S. cities will get data analytics, AI support via international alliance  Smart Cities Dive 6 U.S.",
+    "published": "Mon, 04 Aug 2025 16:42:36 GMT",
+    "source": "Data Analytics",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Near real-time streaming analytics on protobuf with Amazon Redshift - Amazon Web Services",
+    "link": "https://news.google.com/rss/articles/CBMiqgFBVV95cUxPTnNMVUJQVEc0NFpYajBxOS1ma1VBUXc0MlNzTE1VZXBkVDFLOWZYaFgwYTQ2WnVrUkZEYzl6cU1BcFprWk1GcnpFUGNqcGRtR2VmN0ExYlFkYTQtNm53UWJzRkZfdHR1VjVKVVo2UmFnb3N4dGlxT2Z5TEhCaVYtN21scUxmbWRLSk9NRS1FV0xCa1FZczRYZHBYbnpjN180Q2VmTm9sRXMwZw?oc=5",
+    "summary": "Near real-time streaming analytics on protobuf with Amazon Redshift  Amazon Web Services Near real-time streaming analytics on protobuf with Amazon Redshift  Amazon Web Services",
+    "published": "Mon, 04 Aug 2025 17:06:42 GMT",
+    "source": "Data Analytics",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "From Data Scientist IC to Manager: One Year In - Towards Data Science",
+    "link": "https://news.google.com/rss/articles/CBMigwFBVV95cUxQUUFzdjhOSzVlcmhNcWRuZlRGYzZCc3E3T1o1N05xWXVhV2Y1R3NXOFVIMWlQUTRtZVNYV1NVTUVmMEx2dHktU1hWT2ExU3llblg0UXlSdF9nQVFaOVJTWl9Oc0Z1YUl5azctYkNxem5ReTRWNFRCUDU3QVlPc0Y0aklVZw?oc=5",
+    "summary": "From Data Scientist IC to Manager: One Year In  Towards Data Science From Data Scientist IC to Manager: One Year In  Towards Data Science",
+    "published": "Mon, 04 Aug 2025 19:11:05 GMT",
+    "source": "Data Analytics",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Energy Data Analysis Platform for Analysts - Vortexa",
+    "link": "https://news.google.com/rss/articles/CBMiakFVX3lxTFA4Um1xUXNfdkdPYTRRR2J2dWpMR0NFY05paFRmVUZHdTQ0WXhxc1JteFhDLXFKUV96OHhvUzJLV2xxVjBXYmgzYTdYM0daWnRVclFBenRqeF9FTDQxdks0QktibnNudnhmb0E?oc=5",
+    "summary": "Energy Data Analysis Platform for Analysts  Vortexa Energy Data Analysis Platform for Analysts  Vortexa",
+    "published": "Mon, 04 Aug 2025 15:06:46 GMT",
+    "source": "Data Analytics",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "OpenAI’s ChatGPT to hit 700 million weekly users, up 4x from last year - CNBC",
+    "link": "https://news.google.com/rss/articles/CBMieEFVX3lxTFBfdDV5cVBJTC12NTB0ZmlpRXM3WkNrak9xY1U0TWdWOTBpeTA2aVg1ZUJpTUNobE81SFVramVYVGFaWDJxQVRRcFFvWXhlN0s4RXo0RFNZZUkxS21zNkpkcXp2YUlua0dEaHo5Y1FJNVpwVTBVU01Md9IBfkFVX3lxTE1XQUc0eV9rNG1aNWE4d3NHYVFMNGNseW1VZDhPT092M2k3dm4zSUs1ZnZGMm56RThTTzJfb2JmcGJvRWpXWnVLX1NqODFGenFVVWdxcjEwRWhpY3YxT19TVnFvWTJJMnk5WVZJY25BZUVvRGVpanBXeWdjRkxOZw?oc=5",
+    "summary": "OpenAI’s ChatGPT to hit 700 million weekly users, up 4x from last year  CNBC OpenAI’s ChatGPT to hit 700 million weekly users, up 4x from last year  CNBC",
+    "published": "Mon, 04 Aug 2025 15:00:18 GMT",
+    "source": "OpenAI",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "OpenAI says ChatGPT is on track to reach 700M weekly users - TechCrunch",
+    "link": "https://news.google.com/rss/articles/CBMimAFBVV95cUxNV2lnMjExSUpLZWtrNktJNUxxYmp2R0FhWW5uNHlPOTVQQzIwNkl6cFJtMG4taXlyUzlFdXdGYmVxNjluUUN5LWlraW1ScHZQTnRjUTRpR2NhZE1oLXpoa1Z6b2xrVHhOcXZ3MHpoQS1uNWp4VkRUam4xNUl2VDlkUE42WHNUbVo1UFdkZnhSQ3pxbWdjUnpvcg?oc=5",
+    "summary": "OpenAI says ChatGPT is on track to reach 700M weekly users  TechCrunch OpenAI says ChatGPT is on track to reach 700M weekly users  TechCrunch",
+    "published": "Mon, 04 Aug 2025 15:25:13 GMT",
+    "source": "OpenAI",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "OpenAI Adds 200 Million Weekly Users in 4 Months - PYMNTS.com",
+    "link": "https://news.google.com/rss/articles/CBMipgFBVV95cUxQTm5TeW1ETkUwUWJWZ2hpcTBIaEEzakdDblhhWG0xRnc5ejZTOFJyT2lBSWszbXR5SkkxZGwwWm1odkdWQkJWdDdqUm4tWFNreVAtUXBjQkktU2F3M3Q0SVZOenRrMFo3M0w1UGtaRGszV0J0d0ktYnVQSVlDdVYzTk1fN05oaWhvQlZnUTdrbDJleksyX0l4cDBleXFBMHRIakU5WUt3?oc=5",
+    "summary": "OpenAI Adds 200 Million Weekly Users in 4 Months  PYMNTS.com OpenAI Adds 200 Million Weekly Users in 4 Months  PYMNTS.com",
+    "published": "Mon, 04 Aug 2025 20:25:43 GMT",
+    "source": "OpenAI",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Sam Altman teases GPT-5, asks it to recommend the 'most thought-provoking' TV show about AI - Business Insider",
+    "link": "https://news.google.com/rss/articles/CBMifkFVX3lxTE1FZTluR1ppd25WVU9xTWctekxIVVltaDJOdjM3SDVUbGZHT0lxQ1plYUw4THBJenQwbUhXQTRnTHdRcmU1a2V3QzM0ckFIYzloM2YxMTN0TW81dFFxX0JpSU1RMm8wMEZlbWl6Z3VOOWVQZ2hzRndha2RoeG9sdw?oc=5",
+    "summary": "Sam Altman teases GPT-5, asks it to recommend the 'most thought-provoking' TV show about AI  Business Insider Sam Altman teases GPT-5, asks it to recommend the 'most thought-provoking' TV show about AI  Business Insider",
+    "published": "Mon, 04 Aug 2025 00:27:00 GMT",
+    "source": "OpenAI",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Inside OpenAI’s quest to make AI do anything for you - TechCrunch",
+    "link": "https://news.google.com/rss/articles/CBMijwFBVV95cUxQQkZ2LUxGMjYyRkZzSjVTNjlna05MNWhsaUZ6Um9JSjdIaWdKZktGVUJrUVpnaHpuTG1EX3RaQjFqenlSNnZSc2FCUmdHZzdFZTVISTJ0V3g1QVlDRk1uVVNFcm94M0NDRXdjM1FRUW14eEVQMVZMbTdtYUpxamxjYm8xbDNjek0yelNNcV9pSQ?oc=5",
+    "summary": "Inside OpenAI’s quest to make AI do anything for you  TechCrunch Inside OpenAI’s quest to make AI do anything for you  TechCrunch",
+    "published": "Sun, 03 Aug 2025 14:00:00 GMT",
+    "source": "OpenAI",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Anthropic Revokes OpenAI's Access to Claude - WIRED",
+    "link": "https://news.google.com/rss/articles/CBMie0FVX3lxTE10QjlFRm82MUZVTDU1Z0FSdGo4MTVCQm5lUFowLWhoZFB2cjFwV3hLek9wejlEc2liN2FLX0pTbE16V1V1TmdNcUhRU2lwMWh5WktMNzNkWnE2LXRXQ29oTUtVYlZKbThUcjkxZ0NDVG1fSkVOZVFWMVd0aw?oc=5",
+    "summary": "Anthropic Revokes OpenAI's Access to Claude  WIRED Anthropic Revokes OpenAI's Access to Claude  WIRED",
+    "published": "Fri, 01 Aug 2025 21:41:00 GMT",
+    "source": "Anthropic",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Anthropic CEO Dario Amodei says his employees are refusing Zuckerberg’s $100 million payout—and he's not even matching salaries to keep them - Fortune",
+    "link": "https://news.google.com/rss/articles/CBMi6wFBVV95cUxOQXFsNDRkbDlNNTlDTmE3TUlHUGphMjVWY25pNDdJcUZ3TFQxWEZvMklpaE15cy1jVDhfUGhEZXk5dWxGN0g2OXpDcVd6MllHT1A1ay1mN2xJcmlyc0owS2x3ZDBuZjNScnBabElvMTl4WW1wNFFZd25sYWlEY05lLWdabDViSkZQMTdJTVpELXFzT25fUFBWM3FyOVo5WWUtX290M0h4LVBYUDhIZ1gzYWFDVTRpYXhuazc5el9JWWJLb1k1TEk0M1JLbS1Qenk1RFRIQVk4MlFmUmlhU0hjNWRnWDJVdTMyVjhV?oc=5",
+    "summary": "Anthropic CEO Dario Amodei says his employees are refusing Zuckerberg’s $100 million payout—and he's not even matching salaries to keep them  Fortune Anthropic CEO Dario Amodei says his employees are refusing Zuckerberg’s $100 million payout—and he's not even matching salaries to keep them  Fortune",
+    "published": "Mon, 04 Aug 2025 14:36:00 GMT",
+    "source": "Anthropic",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Anthropic cuts off OpenAI’s access to its Claude models - TechCrunch",
+    "link": "https://news.google.com/rss/articles/CBMikwFBVV95cUxQY29pVFlFWVM3bGhiSXJaVDRpRzRLcHdrb1ZUeVVDWDNZZlA0T3dkdTh1bzlEOGxvb29EV00wR3gzaTYzV19HemNyNXhjTkVMenJEcUZUZnBLSnp4cEpTNUd3UFpGOEN2ck8xQW5GN0VNeVlhQ01SbXNuTWFJMVRRUk1qY1BMOUhXVkhjd05lSlBnWmM?oc=5",
+    "summary": "Anthropic cuts off OpenAI’s access to its Claude models  TechCrunchAnthropic reportedly cut OpenAI access to Claude  MashableAnthropic Yanks OpenAI’s Access to Claude Model  PYMNTS.com Anthropic cuts off OpenAI’s access to its Claude models  TechCrunchAnthropic reportedly cut OpenAI access to Claude  MashableAnthropic Yanks OpenAI’s Access to Claude Model  PYMNTS.com",
+    "published": "Sat, 02 Aug 2025 16:55:12 GMT",
+    "source": "Anthropic",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Anthropic CEO Dario Amodei fires back at Nvidia CEO Jensen Huang's criticism, calling it a 'bad faith distortion' - Business Insider",
+    "link": "https://news.google.com/rss/articles/CBMiqAFBVV95cUxON1NPb0xjR2ZRdVBRUW41eFFKVlQ2bmRTMVJoblc3T3gzX1kzY3h0Z0ZnbllTNzYxM2VDOTBiYUtRRkdkdUJYUGxLaDRpNGRxVlV1eWp0ZU1hS2FBSzJJN24ydXRUNGpfaTFXWjNOSktDcUFqYTh5a1VvQzBPTmVza1VycnBGdE1UWFZBM1dlYnFXTUNMTkM0MXlKYkdEbWV0LXptQ2NMZ2o?oc=5",
+    "summary": "Anthropic CEO Dario Amodei fires back at Nvidia CEO Jensen Huang's criticism, calling it a 'bad faith distortion'  Business Insider Anthropic CEO Dario Amodei fires back at Nvidia CEO Jensen Huang's criticism, calling it a 'bad faith distortion'  Business Insider",
+    "published": "Fri, 01 Aug 2025 12:30:00 GMT",
+    "source": "Anthropic",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
+  },
+  {
+    "title": "Can a Chatbot Be Conscious? Claude 4 and the Limits of AI Understanding - Scientific American",
+    "link": "https://news.google.com/rss/articles/CBMirwFBVV95cUxPdC1DdlkyM25nT3dQNUF2V2VFTXNoYW5tQlJBc2VvTUxDcS1wTzlCZWFNeWxtQllvZjNCd3YxY3lxTlZXX0RRVHpyQWVNd2pjbkNVT3BRcHFTR19QdHhxRDEyY3dSRjI3X1NfZDhmd2g5ZGtrWm01Nm1tQzA5QnNHVW53ei15bm1naUR6LXFEczVFN2pMd28xZWlJOG1pZ0U5THI5UWpzaFNoSFBsdFB3?oc=5",
+    "summary": "Can a Chatbot Be Conscious? Claude 4 and the Limits of AI Understanding  Scientific American Can a Chatbot Be Conscious?",
+    "published": "Fri, 01 Aug 2025 10:00:00 GMT",
+    "source": "Anthropic",
+    "category": "industry",
+    "drawbacks": "Consider cost, adoption effort, and governance implications.",
+    "fetched": "2025-08-04"
   },
   {
     "title": "Bear Analytics partners with Microsoft Power BI to accelerate decision-making for event organizers - Microsoft",
@@ -90,64 +717,10 @@
     "drawbacks": "Could require significant compute resources and expert oversight."
   },
   {
-    "title": "Critical Salesforce Tableau Vulnerabilities Let Attackers Execute Code Remotely - CyberSecurityNews",
-    "link": "https://news.google.com/rss/articles/CBMic0FVX3lxTFBQNWR0ZlMwT0ZEdXFabENDTmJITHNjSXpQN0lKRU9NTld1b2lCMndET1RFX0R4Uzc1b25jdks3aWY4YzExNTlGV2l6aVBsNTFKWGdldFJVYXpXOW1ISHhLLXd0TUI2dHpuVHl6X0FqYThjYknSAXhBVV95cUxQN05UTDNKa1A4ejB3YklWcnJoRjQ4M19MbDkxVmlkY2NuQWxRSHhQS0NicVVZTTBrNzZVTFZZWWE3SnBFdzVXYURYdTVTRVBuNmkzb0IzWDlUYWxfTkllVzdzbFNpbU9BanpxaUN5eVYzZTNtQ2dPcWY?oc=5",
-    "summary": "Critical Salesforce Tableau Vulnerabilities Let Attackers Execute Code Remotely  CyberSecurityNews Critical Salesforce Tableau Vulnerabilities Let Attackers Execute Code Remotely  CyberSecurityNews",
-    "published": "Mon, 28 Jul 2025 06:06:42 GMT",
-    "source": "Salesforce",
-    "category": "vendor",
-    "drawbacks": "May raise security and compliance concerns."
-  },
-  {
     "title": "Salesforce Unveils Tableau Next: AI Agents Transform Data Analytics for Business Leaders - SalesforceDevops.net",
     "link": "https://news.google.com/rss/articles/CBMiigFBVV95cUxOYUNzVFJSRHNkVTFMQ0p1Z1A1MmpxeERIWExkTG9seHAtVXpsZTRwOGxQMXpwMW8zeUg3Um9LVVN1d1BXSnlyVlpRbVc0M0YwZ19sVHJkcjl6LU9nNm1SWk1sd0NETEFEUVVLWlJOV2UtellQM3RFekFpd3pHR3JIUGpCSTI0VXdvdXc?oc=5",
     "summary": "Salesforce Unveils Tableau Next: AI Agents Transform Data Analytics for Business Leaders  SalesforceDevops.net Salesforce Unveils Tableau Next: AI Agents Transform Data Analytics for Business Leaders  SalesforceDevops.net",
     "published": "Tue, 15 Apr 2025 07:00:00 GMT",
-    "source": "Salesforce",
-    "category": "vendor",
-    "drawbacks": "Could require significant compute resources and expert oversight."
-  },
-  {
-    "title": "Salesforce Unveils Tableau Next: 5 Big Talking Points - CX Today",
-    "link": "https://news.google.com/rss/articles/CBMiogFBVV95cUxOV2s5NElSY1dxVU5Ma0lWWUpfUkRTN0trbExOOENCSWRkMXNBOGJRUzVGcmZfV1F6VWI1elRESWNmR2hLZEtwR2hCZHNVaUFGVGlSc1JRenB2dHd5amtiTF9sbjFVNWFRWHoxMVdhMmF6VVQxYmRvZXZsYmhXZFlBTTk2Q2V4R1g4VU04T1A3RXJ5UlVzX1ZjSllBczBld29PWXc?oc=5",
-    "summary": "Salesforce Unveils Tableau Next: 5 Big Talking Points  CX Today Salesforce Unveils Tableau Next: 5 Big Talking Points  CX Today",
-    "published": "Tue, 22 Apr 2025 07:00:00 GMT",
-    "source": "Salesforce",
-    "category": "vendor",
-    "drawbacks": "Consider cost, adoption effort, and governance implications."
-  },
-  {
-    "title": "Critical Salesforce Tableau Flaws Allow Remote Code Execution – Patch Immediately! - gbhackers.com",
-    "link": "https://news.google.com/rss/articles/CBMiggFBVV95cUxQU2V0OFhvNzQ5Qm5LVV9TXzdFZUNLbHJHbVhaRG12bG45Uk5OS1dqMWh6LWxsa2VqZWtIN2dyMXhlUEpqM1BFT3NQMmZtWHJsUkxxWTU3b3RhMXdMQmhYdzNPUVBOSGZTUGFsX3JxWG1HeWdpQW1rTGdoUzdXSTZjcm530gGHAUFVX3lxTE43UVdmZFRzOEdQazgtUy00ejItX3R2dGRSNlRjbzZTZW41NUJuVXkzLTdzZFcwQm9nX0ZzY0NQU2s2Z2RCZWVwZ0tpVFNUeWdlNzQwaTR0VGtrUFRtci1hem5XM2tDNU5wcGR3TnpoQWxSVlgzRmtVZkxCY3NPZ2xCYVh0MFQ5OA?oc=5",
-    "summary": "Critical Salesforce Tableau Flaws Allow Remote Code Execution – Patch Immediately!  gbhackers.com Critical Salesforce Tableau Flaws Allow Remote Code Execution – Patch Immediately!  gbhackers.com",
-    "published": "Mon, 28 Jul 2025 04:56:24 GMT",
-    "source": "Salesforce",
-    "category": "vendor",
-    "drawbacks": "Consider cost, adoption effort, and governance implications."
-  },
-  {
-    "title": "Severe Salesforce Tableau Vulnerabilities Enable Remote Code Execution – Urgent Patch Required - Cyber Press",
-    "link": "https://news.google.com/rss/articles/CBMidkFVX3lxTFBHemdaa2RTVGZibW8zYzZaZ1QxOGx5TnVuMUFkVk83YnNHNkhXNF9tZFNmc1NLVGFpeERPODIya0ZhM1Z3MzdoYVcwNEhWWmlzdFlGbG1YSXkyOUQzM2dPTU9PM3AzZzdVZzZSa2w2SUprMC1hb1HSAXZBVV95cUxQR3pnWmtkU1RmYm1vM2M2WmdUMThseU51bjFBZFZPN2JzRzZIVzRfbWRTZnNTS1RhaXhETzgyMmtGYTNWdzM3aGFXMDRIVlppc3RZRmxtWEl5MjlEMzNnT01PTzNwM2c3VWc2UmtsNklKazAtYW9R?oc=5",
-    "summary": "Severe Salesforce Tableau Vulnerabilities Enable Remote Code Execution – Urgent Patch Required  Cyber Press Severe Salesforce Tableau Vulnerabilities Enable Remote Code Execution – Urgent Patch Required  Cyber Press",
-    "published": "Mon, 28 Jul 2025 07:11:47 GMT",
-    "source": "Salesforce",
-    "category": "vendor",
-    "drawbacks": "Consider cost, adoption effort, and governance implications."
-  },
-  {
-    "title": "Salesforce Agentforce: What you need to know - MarTech",
-    "link": "https://news.google.com/rss/articles/CBMickFVX3lxTE9iVUJsbmhIeDdrYjJlZDJOa0hHSXB4U3hSUk5WTmRXTmVZalhvZGx4QjFJMUtEUDV4QWsyNTZjSTdiRE54MGt0TlFoQm5NZDVpN0NhZkVmd1FBN0VBbk9PM0lJS3RXUVRLcmZ2OGxCOW1SUQ?oc=5",
-    "summary": "Salesforce Agentforce: What you need to know  MarTech Salesforce Agentforce: What you need to know  MarTech",
-    "published": "Fri, 25 Jul 2025 07:00:00 GMT",
-    "source": "Salesforce",
-    "category": "vendor",
-    "drawbacks": "Consider cost, adoption effort, and governance implications."
-  },
-  {
-    "title": "Is Salesforce's 30% Upside Potential a Generational Buy Opportunity in the AI-Driven CRM Sector? - AInvest",
-    "link": "https://news.google.com/rss/articles/CBMitgFBVV95cUxNM2l5YkdEdjFzclEwdXp4Y3IxUlp5eXdsdXl0UkZsODhYeHphaWJ2MktOWVVzQkhfcUhrT0tWMzNWVjhOeERtRnM5YklnTUpFMTFGMXRwZW9iUk92R092OUxhUXR3V2RUUVJ5OHRkRHJZamFScGF0RTVRSmlQN3hCUXQyTDBmSE5IVTVXSnZTTi1jaVljVzItR25ac01ObHIxLU5mcU0xdVpUTWQzQ3U5VnhuZlowZw?oc=5",
-    "summary": "Is Salesforce's 30% Upside Potential a Generational Buy Opportunity in the AI-Driven CRM Sector?  AInvest Is Salesforce's 30% Upside Potential a Generational Buy Opportunity in the AI-Driven CRM Sector?  AInvest",
-    "published": "Sun, 03 Aug 2025 17:23:37 GMT",
     "source": "Salesforce",
     "category": "vendor",
     "drawbacks": "Could require significant compute resources and expert oversight."
@@ -160,15 +733,6 @@
     "source": "Salesforce",
     "category": "vendor",
     "drawbacks": "Could require significant compute resources and expert oversight."
-  },
-  {
-    "title": "Salesforce: The Generational Buying Opportunity Is Here (Rating Upgrade) (NYSE:CRM) - Seeking Alpha",
-    "link": "https://news.google.com/rss/articles/CBMiekFVX3lxTE9fazVsQVBqVTlOWlZ3ZXVuS00tZ01SOXlkOE56cEZtRUdNSXFucW5xS1I3RUdER012NTBXaFAzSExFZkpzb29BenQtLURmaks4RHdEajNzTjB1cVFWcC1xa0R3VGdhRlM3aEstV0ZaamRKSFBYWVU5aFhB?oc=5",
-    "summary": "Salesforce: The Generational Buying Opportunity Is Here (Rating Upgrade) (NYSE:CRM)  Seeking Alpha Salesforce: The Generational Buying Opportunity Is Here (Rating Upgrade) (NYSE:CRM)  Seeking Alpha",
-    "published": "Sun, 03 Aug 2025 17:10:15 GMT",
-    "source": "Salesforce",
-    "category": "vendor",
-    "drawbacks": "Consider cost, adoption effort, and governance implications."
   },
   {
     "title": "Agentforce London: 78% of UK companies use agentic AI, says Salesforce - Computer Weekly",
@@ -270,15 +834,6 @@
     "drawbacks": "Could require significant compute resources and expert oversight."
   },
   {
-    "title": "The $196.6 Billion Agentic AI Revolution: Complete Market Analysis, Statistics & Growth Forecast 2025 - Australian Technology News",
-    "link": "https://news.google.com/rss/articles/CBMi1AFBVV95cUxQUTNmOUgwN1VSUlBYSHRSM3BoSVJjTHlndnR5QkdmTS1EcTl3akJSX3N2R3ZKY2ZtOTVscy1nTHY1RnpTY2tEUHk2OEplc05PS2FNMklVRndOMnZ0cm9jTVV3S0pfQWJRSWZuYXVIVFl6X2NnNzBkaU03VmI0N2VnczVsOVg0eEJoUktfQi16Ri15VkR0ZElta3lUdXpRQUlWcm04LTh1ak42Q2tWcGtkOXZiMXdWWmxXb2V0TFctRnZfUzFqaHZnLXVpNWtUcFg4YU5HUA?oc=5",
-    "summary": "The $196.6 Billion Agentic AI Revolution: Complete Market Analysis, Statistics & Growth Forecast 2025  Australian Technology News The $196.6 Billion Agentic AI Revolution: Complete Market Analysis, Statistics & Growth Forecast 2025  Australian Technology News",
-    "published": "Sat, 02 Aug 2025 03:05:18 GMT",
-    "source": "Agentic Analytics",
-    "category": "industry",
-    "drawbacks": "Could require significant compute resources and expert oversight."
-  },
-  {
     "title": "ThoughtSpot Redefines AI Interoperability with Launch of ThoughtSpot Agentic MCP Server - GlobeNewswire",
     "link": "https://news.google.com/rss/articles/CBMi8AFBVV95cUxOa0JVdjIwbWM0M0VaX1NLTzBVcXpTOUpRVWNwNERHQkpTU1JFclBIQ282M1hCR2s2ZE43bXczal9CamVUZWJfQkdGc3dHaklLeWJ1RjMzcWJHZldIQjdMZlVyQ1dnTnJLX3MwUXVkbnBiZmxNOXE2azN6ZUJRNElLZ1pnZzQ0MkRKdlBOZUZXTDdpTTNYVVNWbzV4T1lodkVlakNaci14bjhRYUJ0cFVpeS1jTWIzMjNXbTRFVWQ1SG9OcEEtaDBSMnlJd19Jd1htbVRiZHhfRDN1UTczemRGTTJWcm9XSWVtcXN2WkxyUTM?oc=5",
     "summary": "ThoughtSpot Redefines AI Interoperability with Launch of ThoughtSpot Agentic MCP Server  GlobeNewswire ThoughtSpot Redefines AI Interoperability with Launch of ThoughtSpot Agentic MCP Server  GlobeNewswire",
@@ -288,28 +843,10 @@
     "drawbacks": "Could require significant compute resources and expert oversight."
   },
   {
-    "title": "Momba launches agentic AI solution to transform business analysis and project delivery - AiThority",
-    "link": "https://news.google.com/rss/articles/CBMixAFBVV95cUxOeExheFhKXzBBZTBfYkFmRE9KV1RIUVdZR1hyV0VEZ21PWGFWRDB0TGRxVE9zcFR1aS1XTmtZNS1iTzdaWGdEb0dQX29DdjczLXRJV0h1S0ZrYUU0SXFOMU9uQ3pHLVBrbTRUVjBkZkIxMTMxdmM5Tmw1azZjRlJwWjBjMVJGblhtRGdJTVpHOFhFU3psRERvSTZ4QTNRNTlmX2VRYXlrWmdUb1pON2hsQzRiSzdoTXVUUm1fOGJsQ1hJNVh2?oc=5",
-    "summary": "Momba launches agentic AI solution to transform business analysis and project delivery  AiThority Momba launches agentic AI solution to transform business analysis and project delivery  AiThority",
-    "published": "Wed, 30 Jul 2025 15:09:20 GMT",
-    "source": "Agentic Analytics",
-    "category": "industry",
-    "drawbacks": "Could require significant compute resources and expert oversight."
-  },
-  {
     "title": "Getting real about agentic AI, from protocols to data platforms - more inbox adventures with AI vendors - Diginomica",
     "link": "https://news.google.com/rss/articles/CBMirwFBVV95cUxQM0ZlR1pIUW80R3U2bmdfdVZ1amcyVE1Bd29WcXF0eThUVHdGcE1fX2luMm12YTliVGpHVHhBbjlTYkFMSkR0VGtlTFZCWjNiTmhzZGJwSVc3aHdhNEpDTkVmQWhYWUtYdFNkQ0E5YUpXWWNETndyODNQOHRLc2tvSzh3dUxNczFpR3NVY3dsX1E4TmtfaDlvZGVOamNNaVBLQXVtdDBnNV9Nd3hYVXhJ0gG0AUFVX3lxTE1YTk9oNjRmbXdvN2JZVHU1SDF6NmVlMEh1SUJvLW1LYVV6QzVFRUNMc3V4cEZCTUd0dDFQbVBRVTN4aXFGZDd6X2IwX1NaTGE2ZmdCOWRiTTZYNTQtRm91b1dYTnFYZEFYZy1LcWpIUDBzMkJxZ3BlRmdoUnEwaG5FNHBIdjBIQm9TajZoS3ZhaTlOMURncTJBVUpoQkpmbXVRT1pKT2I1WlFmZGlaLXhHelVmaQ?oc=5",
     "summary": "Getting real about agentic AI, from protocols to data platforms - more inbox adventures with AI vendors  Diginomica Getting real about agentic AI, from protocols to data platforms - more inbox adventures with AI vendors  Diginomica",
     "published": "Tue, 22 Jul 2025 07:00:00 GMT",
-    "source": "Agentic Analytics",
-    "category": "industry",
-    "drawbacks": "Could require significant compute resources and expert oversight."
-  },
-  {
-    "title": "Qrvey 9.1 Accelerates Embedded Analytics With Agentic AI and a Faster Path to Deployment - Yahoo Finance",
-    "link": "https://news.google.com/rss/articles/CBMiggFBVV95cUxPc1d1RE9uYUdqeGpqeGFVMFNDR1oyM1hIM3lyNTd4UEZmWG51MkhLTTFWQ2JjZ2ZuYjE0bE1DTHBpQWMyb1hhVmRTRWVoZ2hKRVZFbXF1VFJheU4zcXlGazhzMGJidE0tWUJ4U1IxWlBDbjJFczk0T3MwT2xTNE5JNjRn?oc=5",
-    "summary": "Qrvey 9.1 Accelerates Embedded Analytics With Agentic AI and a Faster Path to Deployment  Yahoo Finance Qrvey 9.1 Accelerates Embedded Analytics With Agentic AI and a Faster Path to Deployment  Yahoo Finance",
-    "published": "Tue, 29 Jul 2025 12:00:00 GMT",
     "source": "Agentic Analytics",
     "category": "industry",
     "drawbacks": "Could require significant compute resources and expert oversight."

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,12 +24,13 @@ export default function App() {
 
   const today = new Date().toISOString().slice(0, 10);
   const latest = filtered.filter((a) => a.fetched === today);
+  const homeArticles = latest.length ? latest : filtered;
   const older = filtered.filter((a) => a.fetched !== today);
 
   return (
     <Routes>
       <Route element={<Layout query={query} setQuery={setQuery} />}>
-        <Route index element={<Home articles={latest} />} />
+        <Route index element={<Home articles={homeArticles} />} />
         <Route path="vendors" element={<Vendors articles={filtered} />} />
         <Route path="industry" element={<Industry articles={filtered} />} />
         <Route path="older" element={<Older articles={older} />} />

--- a/frontend/src/components/Section.jsx
+++ b/frontend/src/components/Section.jsx
@@ -4,21 +4,29 @@ export default function Section({ title, articles }) {
   if (!articles.length) return null;
   return (
     <section className="section">
-      <h2>{title}</h2>
-      {articles.map((art) => (
-        <article key={art.link} className="card">
-          <h3>
-            <a href={art.link} target="_blank" rel="noopener noreferrer">
-              {art.title}
-            </a>
-          </h3>
-          {art.published && <p><em>{art.published}</em></p>}
-          {art.summary && <p>{art.summary}</p>}
-          {art.drawbacks && (
-            <p><strong>Potential drawbacks:</strong> {art.drawbacks}</p>
-          )}
-        </article>
-      ))}
+      {title && <h2>{title}</h2>}
+      <div className="cards">
+        {articles.map((art) => (
+          <article key={art.link} className="card">
+            <h3>
+              <a href={art.link} target="_blank" rel="noopener noreferrer">
+                {art.title}
+              </a>
+            </h3>
+            {art.published && (
+              <p>
+                <em>{art.published}</em>
+              </p>
+            )}
+            {art.summary && <p>{art.summary}</p>}
+            {art.drawbacks && (
+              <p>
+                <strong>Potential drawbacks:</strong> {art.drawbacks}
+              </p>
+            )}
+          </article>
+        ))}
+      </div>
     </section>
   );
 }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -2,9 +2,40 @@ import React from 'react';
 import Section from '../components/Section.jsx';
 
 export default function Home({ articles }) {
+  if (!articles.length) {
+    return <p className="empty">No articles available.</p>;
+  }
+
+  const priority = [
+    'Databricks',
+    'Snowflake',
+    'Microsoft',
+    'Sigma Computing',
+    'Salesforce',
+    'Qlik',
+    'Looker',
+    'Google',
+    'OpenAI',
+    'Anthropic',
+    'Tableau',
+  ];
+  const prioritySet = new Set(priority);
+
+  const sorted = [...articles].sort((a, b) => {
+    const aPri = prioritySet.has(a.source);
+    const bPri = prioritySet.has(b.source);
+    if (aPri !== bPri) return bPri - aPri;
+    return new Date(b.fetched || 0) - new Date(a.fetched || 0);
+  });
+
+  const topTen = sorted.slice(0, 10);
+  const top = topTen.filter((a) => prioritySet.has(a.source));
+  const rest = topTen.filter((a) => !prioritySet.has(a.source));
+
   return (
-    <div>
-      <Section title="Latest" articles={articles} />
+    <div className="home">
+      {top.length > 0 && <Section title="Top News" articles={top} />}
+      {rest.length > 0 && <Section title="Latest" articles={rest} />}
     </div>
   );
 }

--- a/frontend/src/pages/Older.jsx
+++ b/frontend/src/pages/Older.jsx
@@ -3,16 +3,20 @@ import Section from '../components/Section.jsx';
 
 export default function Older({ articles }) {
   const grouped = articles.reduce((acc, art) => {
-    const date = art.fetched || 'Unknown';
-    (acc[date] = acc[date] || []).push(art);
+    const vendor = art.source || 'Unknown';
+    (acc[vendor] = acc[vendor] || []).push(art);
     return acc;
   }, {});
 
   return (
-    <div>
-      {Object.entries(grouped).map(([date, arts]) => (
-        <Section key={date} title={date} articles={arts} />
+    <div className="vendor-folders">
+      {Object.entries(grouped).map(([vendor, arts]) => (
+        <details key={vendor}>
+          <summary>{vendor}</summary>
+          <Section articles={arts} />
+        </details>
       ))}
     </div>
   );
 }
+

--- a/frontend/src/pages/Vendors.jsx
+++ b/frontend/src/pages/Vendors.jsx
@@ -9,9 +9,12 @@ export default function Vendors({ articles }) {
   }, {});
 
   return (
-    <div>
+    <div className="vendor-folders">
       {Object.entries(grouped).map(([vendor, arts]) => (
-        <Section key={vendor} title={vendor} articles={arts} />
+        <details key={vendor}>
+          <summary>{vendor}</summary>
+          <Section articles={arts} />
+        </details>
       ))}
     </div>
   );

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,18 +1,22 @@
+/* ThoughtSpot-inspired palette and gradients */
 :root {
-  --ts-blue: #0c2d48;
-  --ts-light: #f5f6f8;
-  --ts-dark: #0a1f44;
+  --ts-primary: #4e3289;
+  --ts-secondary: #00b4d8;
+  --ts-bg: #ffffff;
+  --ts-surface: #f5f5f5;
+  --ts-text: #000000;
 }
 
 body {
   margin: 0;
   font-family: 'Segoe UI', Tahoma, sans-serif;
-  background: var(--ts-light);
-  color: var(--ts-dark);
+  background: var(--ts-bg);
+  min-height: 100vh;
+  color: var(--ts-text);
 }
 
 .navbar {
-  background: var(--ts-blue);
+  background: linear-gradient(90deg, var(--ts-primary) 0%, var(--ts-secondary) 100%);
   color: #fff;
   display: flex;
   align-items: center;
@@ -45,6 +49,8 @@ body {
   border: none;
   border-radius: 4px;
   min-width: 200px;
+  background: #fff;
+  color: #000;
 }
 
 .content {
@@ -54,24 +60,63 @@ body {
 }
 
 .section {
-  margin-bottom: 2rem;
+  margin-bottom: 3rem;
 }
 
 .section h2 {
-  border-bottom: 2px solid var(--ts-blue);
+  color: var(--ts-secondary);
+  border-bottom: 2px solid var(--ts-primary);
   padding-bottom: 0.25rem;
   margin-bottom: 1rem;
 }
 
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
 .card {
-  background: #fff;
-  border: 1px solid #e0e0e0;
+  background: var(--ts-surface);
+  border-left: 4px solid var(--ts-primary);
   border-radius: 8px;
   padding: 1rem;
-  margin-bottom: 1rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
 }
 
 .card h3 {
   margin-top: 0;
+}
+
+.card h3 a {
+  color: var(--ts-secondary);
+}
+
+a {
+  color: var(--ts-secondary);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--ts-primary);
+}
+
+.vendor-folders summary {
+  cursor: pointer;
+  font-size: 1.25rem;
+  color: var(--ts-text);
+  background: var(--ts-surface);
+  padding: 0.5rem 1rem;
+  border-left: 4px solid var(--ts-primary);
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+}
+
+.vendor-folders details {
+  margin-bottom: 1rem;
+}
+
+.empty {
+  text-align: center;
+  margin-top: 2rem;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -27,100 +27,180 @@
       
       <li><a href="https://blogs.microsoft.com/blog/2025/04/28/how-agentic-ai-is-driving-ai-first-business-transformation-for-customers-to-achieve-more/">How agentic AI is driving AI-first business transformation for customers to achieve more</a> - Mon, 28 Apr 2025 15:59:56 +0000</li>
       
-      <li><a href="https://news.google.com/rss/articles/CBMi0AFBVV95cUxNQUV4Tm9xZmlrcE1IZmtLX3h5VXl5eVdvem0ybEljbndTVG5XYXRmQ0JjU2NWc3htcmpCRGZOUWx3S3JNdy1nMUQxRndtYS1UNXhrV0Z4Z3dFSmR1VmVubEthMUpWTnM0RU5lbzFEMzR6WFBsdG80S0RhNG5LWHEtTlJmR2g5ZDRYTzZheTlnWEVTRHFEU0lscWs2TTdndmM3MjhhcmV0cDZDalFoNTZ4SXdFcy03VzJ6NVRNcnFRZDRqMTZGSk1abmpraThaY0s3?oc=5">Copilot, agents, and apps at the Power Platform Community Conference 2025 - Microsoft</a> - Thu, 31 Jul 2025 15:00:00 GMT</li>
-      
       <li><a href="https://news.google.com/rss/articles/CBMiqwFBVV95cUxOSjRQSWk0QWdWN2hvMkFwdWpIemdVYWtvUkdwWGVLOWc4Yk9oNFc1eWMya1dGRGNBMmsyTUtSSXZGdDZJTFJoU1R1OGJSREN6VmNYbkxXS2x2UFJVd2REeUFKQXMtUjFpU0R1ajRDSzBLSEhsa2xFRG94SjlULVpvUnBUVWJwVDlBd3RUT1I4bjdOQ2VXRFFDZXUwdHdrVkFWYUtKMkRDYW5kdm8?oc=5">How Microsoft Power BI Elevated My Data Analysis and Visualization Workflow - Towards Data Science</a> - Tue, 27 May 2025 07:00:00 GMT</li>
       
-      <li><a href="https://news.google.com/rss/articles/CBMiigFBVV95cUxOdUFhaFFOTDdLTHVEQjZSU01mZmZQb21qZk44YlRCVUJVSDJFczZoazc5RDFUN0ZyWThpN0xDY3FoZHdsZk0wUFpkc0VWNHB0azItUVZDVlNWWWxBTlNDeXlaT1lEa2doZzlaTjh6NnR4UUUxcmJpTzFEb3ZoZWs1QUY5WF9JQkpXWFE?oc=5">Bear Analytics partners with Microsoft Power BI to accelerate decision-making for event organizers - Microsoft</a> - Mon, 10 Mar 2025 07:00:00 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMi2wFBVV95cUxNME5hYTFnaE4wRmttRHFhVEw3ZW96NHV2UzR6bDkwdGpsNkJuMi1Tb2dkQTlNaG5yWHpndDBudVB3Rktscms2UmZnOEtJeHlFSXFGUTEyUm51aERaT0UxWmJ5cDdzNERQMkNIaFpwYXkzb0ZpZFFHY0hBMzlJNVVpeVE3Q216dFFVcUQwM1ZfLTkzcG1uandVYVRkcjR6NjdWMlZYZjE3Yl8zcUIwT2JxeGpfWjF2aGdLTG1rWDRlTDI1d1E1bThfTjlIMHVTTFJ5X1dKck1wR1FnVkU?oc=5">AI-powered success—with more than 1,000 stories of customer transformation and innovation - Microsoft</a> - Thu, 24 Jul 2025 07:00:00 GMT</li>
       
-      <li><a href="https://news.google.com/rss/articles/CBMihAFBVV95cUxOTjlna3JLR3pkOFE0TEpUZUg2Y3ppZGJjb2VpY0dCZFRiQ2Rjc3N2QnNUQTNhWTI1emI4RjZiU2x0YXUzeFJiUzRXTlpTYU5Camw2ZkZ6VU1maWpmWC1CLXZfZ1ZXV1N0RndZbE9ic3UxUEs3dExTanl3aEV1US12TjNkSmw?oc=5">The Co-op leverages Azure Synapse Analytics and Power BI to build a stronger community - Microsoft</a> - Wed, 02 Apr 2025 10:16:09 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMisAFBVV95cUxQYkVoRWJkTldBV0pWVmZIZUdYeldNbnRVLWZabWtqdWlrS0MyN0FING9SanRkOEQyUTE2R0piMThVdHVwZmNCMmE0YzR5QUNGNS1lbVl2M2xpTWtkaTFqZkY0dExrU2luU2Q0aGc3X1g2RHZZNVN5dGhZeEptN2dqb05hRV80ZS1HbVdMMHlLVlcya3BXODFwVFNONWE5XzVqTWFXa0dvbURYVnZ5TmtLQw?oc=5">What’s new in Power Apps: May 2025 Feature Update - Microsoft</a> - Mon, 09 Jun 2025 07:00:00 GMT</li>
       
-      <li><a href="https://news.google.com/rss/articles/CBMidkFVX3lxTE52elpvVHZqdUZrajBObnV3OFlYc1NVNVZYa2VhOTBQeGEyT0Naa21XM3gxOU40aXlDNXlTd0hJSVNpcS1wVjU4QTR1U1pVQXluZHc5WVB6SXdPY3BNYmE3UjlkS0lsbmd6VVd0cmNHRVVid1RLNHc?oc=5">Genpact leverages Microsoft Fabric for AI-driven data transformation - Microsoft</a> - Fri, 20 Jun 2025 07:00:00 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMiswFBVV95cUxQeWFZUllBam9sakxsamZ5TUdIVGlyY0dEUjFPVlFGRFRQSVltMTgxbEU1aWZ0Szd2NDRyY2Rza0JTWV85UnhBZmxIaDJvd3FIQnpmTnVrVnU4WGFFWFU3aW9WYnp1QWh4a0xNQ3pnYUVDU3haY012TVRaZjR4UElMcHNZZWVOMVBmVkRHVXhjd2p6cC1sWFdTY0hXSjVZLUY2dmo0RGQ3NlNaM1lhb3lQaHZVdw?oc=5">What’s new in Power Apps: March 2025 Feature Update - Microsoft</a> - Fri, 04 Apr 2025 07:00:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMiswFBVV95cUxPTHVDQzBIODNhdFM3bld2U1QyM2RhRXBiZE1uVE9xQnFXN2h6N3ZJNXVkc25vVUJOZHNicjFKRXNHbE02UFZuNW9DaVRhMzl6TFY5MVFQZS1Lcl9MUWk1MUdBdVlwNnZVQVM3cVRDQUVxblF6dGhPSVVWNHduMjBvZnpvN0szV0NPWGRfRkFmcTNRQ2M2Wnc5bS1VZEtzMXZ3bHdmYmNxR2tpby04T0lDU1JEMA?oc=5">What’s new in Power Apps: April 2025 Feature Update - Microsoft</a> - Fri, 09 May 2025 07:00:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMi0AFBVV95cUxNQUV4Tm9xZmlrcE1IZmtLX3h5VXl5eVdvem0ybEljbndTVG5XYXRmQ0JjU2NWc3htcmpCRGZOUWx3S3JNdy1nMUQxRndtYS1UNXhrV0Z4Z3dFSmR1VmVubEthMUpWTnM0RU5lbzFEMzR6WFBsdG80S0RhNG5LWHEtTlJmR2g5ZDRYTzZheTlnWEVTRHFEU0lscWs2TTdndmM3MjhhcmV0cDZDalFoNTZ4SXdFcy03VzJ6NVRNcnFRZDRqMTZGSk1abmpraThaY0s3?oc=5">Copilot, agents, and apps at the Power Platform Community Conference 2025 - Microsoft</a> - Thu, 31 Jul 2025 15:00:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMi2wFBVV95cUxNME5hYTFnaE4wRmttRHFhVEw3ZW96NHV2UzR6bDkwdGpsNkJuMi1Tb2dkQTlNaG5yWHpndDBudVB3Rktscms2UmZnOEtJeHlFSXFGUTEyUm51aERaT0UxWmJ5cDdzNERQMkNIaFpwYXkzb0ZpZFFHY0hBMzlJNVVpeVE3Q216dFFVcUQwM1ZfLTkzcG1uandVYVRkcjR6NjdWMlZYZjE3Yl8zcUIwT2JxeGpfWjF2aGdLTG1rWDRlTDI1d1E1bThfTjlIMHVTTFJ5X1dKck1wR1FnVkU?oc=5">AI-powered success—with more than 1,000 stories of customer transformation and innovation - Microsoft</a> - Thu, 24 Jul 2025 07:00:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMiswFBVV95cUxNME9ScnpZMFVVaS1ZZ2pxZi1OOXByM1VEcjBVRXM2R0trVE9NV0VkVVFaTVhUVWVXazduNHZ2eURJR3Fha0lQX2xEcmlqUHM5akp3ejFubVZpLXhrdlNOTmdkZEdidXFHaHZKb2RDelc5cnVZclpRZXJRZ25MZFU2aHBCdFk2YnFaY0h6SnJ5d2RXVV9kQko1WHp0d0lqMDFGQTJzUXE0VHpHVktPVTFWN0l0bw?oc=5">Sessions you won’t want to miss at FabCon Vienna - Microsoft</a> - Mon, 28 Jul 2025 15:00:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMipAJBVV95cUxOcTZqSVpibWh5T0VyUXFlbF9RNkRjVVUzbkN1ZkIzeGYwSWQxbXNlMm9pZHhYTjA1VmZuSERleDRjdHphNktMd0diUzI3a3QtQTNwblhNa2JKM3E3N3F6RWxGRXZsQ3VXZ0FwbWhSU1haUUNSQkUyTnVrcGRmTEgzOWk2aGdoSHIyWnQxeWd2UE5FYUhodE5XVl96WEs1bDUyV2ppc0VMRlp0MVlTMFB6YnA3QVM2QjNxZnBXTUxUcXF6MG55T3dIVFNFU0pUZGdMMmlOR0hnRXJ6U1JabFlXLVdxRVlKdUF2RU9kU3RyVlZrUW45ei1hek9IMUR2SWFFMHRQbDcxLXV4QmlqTVJPUXhIenVZT25kV0N4VXliR3l4ZWpt?oc=5">2025 release wave 2 plans for Microsoft Dynamics 365, Microsoft Power Platform, and Role-based Microsoft Copilot offerings - Microsoft</a> - Wed, 16 Jul 2025 07:00:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMivAFBVV95cUxNWi0zQW1ucXYtQVV0dVRITjVEUUZSZDBvQkpBSFFVODlnSTZLSjBIdHVNZDBmOFdpcmVQUDlPUHZiODlxTklQUl9PeHp0ZnU5QzB4X1NHVmRaUWZ3NHQzRFg0Y0w5SWtQZXh0Wml6eklVSjZpLWx0MFlZMXNpTEhWeHRkS1ZVUjFKSGt2TkNmTEJYNUpfWHhpQW1Rb1FUVloyRXZhUHZqSFZJc3BnejVJTVdDckdZaEo5dDBKVg?oc=5">Powering the next AI frontier with Microsoft Fabric and the Azure data portfolio - Microsoft Azure</a> - Mon, 19 May 2025 07:00:00 GMT</li>
       
     </ul>
     
     <h2>Salesforce</h2>
     <ul>
       
-      <li><a href="https://news.google.com/rss/articles/CBMic0FVX3lxTFBQNWR0ZlMwT0ZEdXFabENDTmJITHNjSXpQN0lKRU9NTld1b2lCMndET1RFX0R4Uzc1b25jdks3aWY4YzExNTlGV2l6aVBsNTFKWGdldFJVYXpXOW1ISHhLLXd0TUI2dHpuVHl6X0FqYThjYknSAXhBVV95cUxQN05UTDNKa1A4ejB3YklWcnJoRjQ4M19MbDkxVmlkY2NuQWxRSHhQS0NicVVZTTBrNzZVTFZZWWE3SnBFdzVXYURYdTVTRVBuNmkzb0IzWDlUYWxfTkllVzdzbFNpbU9BanpxaUN5eVYzZTNtQ2dPcWY?oc=5">Critical Salesforce Tableau Vulnerabilities Let Attackers Execute Code Remotely - CyberSecurityNews</a> - Mon, 28 Jul 2025 06:06:42 GMT</li>
-      
-      <li><a href="https://news.google.com/rss/articles/CBMiigFBVV95cUxOYUNzVFJSRHNkVTFMQ0p1Z1A1MmpxeERIWExkTG9seHAtVXpsZTRwOGxQMXpwMW8zeUg3Um9LVVN1d1BXSnlyVlpRbVc0M0YwZ19sVHJkcjl6LU9nNm1SWk1sd0NETEFEUVVLWlJOV2UtellQM3RFekFpd3pHR3JIUGpCSTI0VXdvdXc?oc=5">Salesforce Unveils Tableau Next: AI Agents Transform Data Analytics for Business Leaders - SalesforceDevops.net</a> - Tue, 15 Apr 2025 07:00:00 GMT</li>
-      
-      <li><a href="https://news.google.com/rss/articles/CBMiogFBVV95cUxOV2s5NElSY1dxVU5Ma0lWWUpfUkRTN0trbExOOENCSWRkMXNBOGJRUzVGcmZfV1F6VWI1elRESWNmR2hLZEtwR2hCZHNVaUFGVGlSc1JRenB2dHd5amtiTF9sbjFVNWFRWHoxMVdhMmF6VVQxYmRvZXZsYmhXZFlBTTk2Q2V4R1g4VU04T1A3RXJ5UlVzX1ZjSllBczBld29PWXc?oc=5">Salesforce Unveils Tableau Next: 5 Big Talking Points - CX Today</a> - Tue, 22 Apr 2025 07:00:00 GMT</li>
-      
       <li><a href="https://news.google.com/rss/articles/CBMiggFBVV95cUxQU2V0OFhvNzQ5Qm5LVV9TXzdFZUNLbHJHbVhaRG12bG45Uk5OS1dqMWh6LWxsa2VqZWtIN2dyMXhlUEpqM1BFT3NQMmZtWHJsUkxxWTU3b3RhMXdMQmhYdzNPUVBOSGZTUGFsX3JxWG1HeWdpQW1rTGdoUzdXSTZjcm530gGHAUFVX3lxTE43UVdmZFRzOEdQazgtUy00ejItX3R2dGRSNlRjbzZTZW41NUJuVXkzLTdzZFcwQm9nX0ZzY0NQU2s2Z2RCZWVwZ0tpVFNUeWdlNzQwaTR0VGtrUFRtci1hem5XM2tDNU5wcGR3TnpoQWxSVlgzRmtVZkxCY3NPZ2xCYVh0MFQ5OA?oc=5">Critical Salesforce Tableau Flaws Allow Remote Code Execution – Patch Immediately! - gbhackers.com</a> - Mon, 28 Jul 2025 04:56:24 GMT</li>
       
       <li><a href="https://news.google.com/rss/articles/CBMidkFVX3lxTFBHemdaa2RTVGZibW8zYzZaZ1QxOGx5TnVuMUFkVk83YnNHNkhXNF9tZFNmc1NLVGFpeERPODIya0ZhM1Z3MzdoYVcwNEhWWmlzdFlGbG1YSXkyOUQzM2dPTU9PM3AzZzdVZzZSa2w2SUprMC1hb1HSAXZBVV95cUxQR3pnWmtkU1RmYm1vM2M2WmdUMThseU51bjFBZFZPN2JzRzZIVzRfbWRTZnNTS1RhaXhETzgyMmtGYTNWdzM3aGFXMDRIVlppc3RZRmxtWEl5MjlEMzNnT01PTzNwM2c3VWc2UmtsNklKazAtYW9R?oc=5">Severe Salesforce Tableau Vulnerabilities Enable Remote Code Execution – Urgent Patch Required - Cyber Press</a> - Mon, 28 Jul 2025 07:11:47 GMT</li>
       
+      <li><a href="https://news.google.com/rss/articles/CBMic0FVX3lxTFBQNWR0ZlMwT0ZEdXFabENDTmJITHNjSXpQN0lKRU9NTld1b2lCMndET1RFX0R4Uzc1b25jdks3aWY4YzExNTlGV2l6aVBsNTFKWGdldFJVYXpXOW1ISHhLLXd0TUI2dHpuVHl6X0FqYThjYknSAXhBVV95cUxQN05UTDNKa1A4ejB3YklWcnJoRjQ4M19MbDkxVmlkY2NuQWxRSHhQS0NicVVZTTBrNzZVTFZZWWE3SnBFdzVXYURYdTVTRVBuNmkzb0IzWDlUYWxfTkllVzdzbFNpbU9BanpxaUN5eVYzZTNtQ2dPcWY?oc=5">Critical Salesforce Tableau Vulnerabilities Let Attackers Execute Code Remotely - CyberSecurityNews</a> - Mon, 28 Jul 2025 06:06:42 GMT</li>
+      
       <li><a href="https://news.google.com/rss/articles/CBMickFVX3lxTE9iVUJsbmhIeDdrYjJlZDJOa0hHSXB4U3hSUk5WTmRXTmVZalhvZGx4QjFJMUtEUDV4QWsyNTZjSTdiRE54MGt0TlFoQm5NZDVpN0NhZkVmd1FBN0VBbk9PM0lJS3RXUVRLcmZ2OGxCOW1SUQ?oc=5">Salesforce Agentforce: What you need to know - MarTech</a> - Fri, 25 Jul 2025 07:00:00 GMT</li>
       
-      <li><a href="https://news.google.com/rss/articles/CBMitgFBVV95cUxNM2l5YkdEdjFzclEwdXp4Y3IxUlp5eXdsdXl0UkZsODhYeHphaWJ2MktOWVVzQkhfcUhrT0tWMzNWVjhOeERtRnM5YklnTUpFMTFGMXRwZW9iUk92R092OUxhUXR3V2RUUVJ5OHRkRHJZamFScGF0RTVRSmlQN3hCUXQyTDBmSE5IVTVXSnZTTi1jaVljVzItR25ac01ObHIxLU5mcU0xdVpUTWQzQ3U5VnhuZlowZw?oc=5">Is Salesforce&#39;s 30% Upside Potential a Generational Buy Opportunity in the AI-Driven CRM Sector? - AInvest</a> - Sun, 03 Aug 2025 17:23:37 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMiogFBVV95cUxOV2s5NElSY1dxVU5Ma0lWWUpfUkRTN0trbExOOENCSWRkMXNBOGJRUzVGcmZfV1F6VWI1elRESWNmR2hLZEtwR2hCZHNVaUFGVGlSc1JRenB2dHd5amtiTF9sbjFVNWFRWHoxMVdhMmF6VVQxYmRvZXZsYmhXZFlBTTk2Q2V4R1g4VU04T1A3RXJ5UlVzX1ZjSllBczBld29PWXc?oc=5">Salesforce Unveils Tableau Next: 5 Big Talking Points - CX Today</a> - Tue, 22 Apr 2025 07:00:00 GMT</li>
       
-      <li><a href="https://news.google.com/rss/articles/CBMiugFBVV95cUxNcVdQY0tDaUl6Rk1sdmJXdU85dFh1YlNaanVVVVNyQmtiMDlwcE13OTFJSVdHUkJ4SURIZUdrQ2ZUaF9QVzV0OFBWX2c5T2ppM2lYNng5NzVFMEhfaUN3ZTBWdmRJcEk4LXRaQ2J0dm5FRkx1R21OZTBqVThmbzJpeHZLbUg2aElKVWJWd3ZDT3NSMnZ1eHNVeU9UeDBCVGtfZ043cGpPM3A5MVpBZWo3cVpjQjN5UXpHYVE?oc=5">Capita leverages Salesforce’s Agentforce, aiming to become the UK’s leading agent-driven outsourcing solution - Capita</a> - Wed, 11 Jun 2025 07:00:00 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMiuAFBVV95cUxQSFRvSjVtdEJQYkk5d2N4UndudzlyTEdrYllPSVU3UHBHSHpCLTlUUmRoSG51S19DcGJqbFV1TGc1Rkd6UHlEUlJHM09kZ3gzeXJjTTI4OTVEanVfcHBmcTdfQXluX3V3WkY2NUl2WmhTUlVFMXZBUl83cy1NT2VvUzRPbnZjLS1SWGdyZmZZa1FJSmJnZG9sMWN2YnZFRGEwck5BSEg3ZmR2OS1OSVdaM21WbjBTR3FI?oc=5">PepsiCo Leverages Salesforce&#39;s Agentforce to Advance AI Agenda - PR Newswire</a> - Tue, 24 Jun 2025 07:00:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMihgFBVV95cUxPTHloLVBxZWUwTXNBT21MajAxSmNVSi13SVEzaWNjbHNHYm84YjBJbExZSHYydGgxeVlEQTVCT0dzX2FBQm1LcXJFR2FvdndaSTg2NHhIUjhsWE1KOE81UHZaZjVKanJleUNsTFpjX055d0VLd3JzdFZ2QTdqRzdjOUFWOGZyZw?oc=5">Salesforce Bets Big on Agentforce: Can AI Agents Power Growth? - Yahoo Finance</a> - Thu, 17 Jul 2025 07:00:00 GMT</li>
       
       <li><a href="https://news.google.com/rss/articles/CBMiekFVX3lxTE9fazVsQVBqVTlOWlZ3ZXVuS00tZ01SOXlkOE56cEZtRUdNSXFucW5xS1I3RUdER012NTBXaFAzSExFZkpzb29BenQtLURmaks4RHdEajNzTjB1cVFWcC1xa0R3VGdhRlM3aEstV0ZaamRKSFBYWVU5aFhB?oc=5">Salesforce: The Generational Buying Opportunity Is Here (Rating Upgrade) (NYSE:CRM) - Seeking Alpha</a> - Sun, 03 Aug 2025 17:10:15 GMT</li>
       
-      <li><a href="https://news.google.com/rss/articles/CBMiswFBVV95cUxPZ0VBVElkcTZMNGNQZm40bGRiaHZJOVlZVmFnRzBzUkhVeUQ1OUJlNjNDZWh4aXJSOXhqeTdsQmtyVFBiczJkc3FBV3ZEOFlKVXdEc0NiNTBxSkVWS0duckt2UEJVTlhUVjg1LTJ4QnMwQkFNeHYySGNjeE5aRElGXzVCVE0zb2NqMzJLc0RLc0lVa1lCcTJVSWM5M1NPZFdnekFybDFPNDZoMndtTkZJdW1yNA?oc=5">Agentforce London: 78% of UK companies use agentic AI, says Salesforce - Computer Weekly</a> - Thu, 12 Jun 2025 07:00:00 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMitgFBVV95cUxNM2l5YkdEdjFzclEwdXp4Y3IxUlp5eXdsdXl0UkZsODhYeHphaWJ2MktOWVVzQkhfcUhrT0tWMzNWVjhOeERtRnM5YklnTUpFMTFGMXRwZW9iUk92R092OUxhUXR3V2RUUVJ5OHRkRHJZamFScGF0RTVRSmlQN3hCUXQyTDBmSE5IVTVXSnZTTi1jaVljVzItR25ac01ObHIxLU5mcU0xdVpUTWQzQ3U5VnhuZlowZw?oc=5">Is Salesforce&#39;s 30% Upside Potential a Generational Buy Opportunity in the AI-Driven CRM Sector? - AInvest</a> - Sun, 03 Aug 2025 17:23:37 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMitAFBVV95cUxPdk5CX2hreVhjazRpVGlvSlNkczRFcW5zUVBvSEJQeUNrbUVWVl9qb1BQTjUxejZqWm02YzRVWHl2TENxVUpkR0NsV3hyRFFNVElBNkZrU1IzVjI2WjBGRzNnMWJSLVhCbHB4ay1zQS1GOUFaSGUwX0Q4dnVzWlZ6aDRZaUlYbkgteTBJN2Vac0x2ZkFKZEJXT0NWR0xLdVAweFdEUEhycEtWZ053VFUxTlFScFY?oc=5">Salesforce Agentforce 3 promises new ways to monitor and manage AI agents - cio.com</a> - Tue, 24 Jun 2025 07:00:00 GMT</li>
       
     </ul>
     
     <h2>Snowflake</h2>
     <ul>
       
-      <li><a href="https://www.snowflake.com/content/snowflake-site/global/en/blog/ai-observability-trust-cortex-enterprise">Unlocking Trust in Enterprise AI with AI Observability and Evaluations in Snowflake Cortex AI</a> - Fri, 01 Aug 2025 13:28:00 -0700</li>
+      <li><a href="https://news.google.com/rss/articles/CBMiyAFBVV95cUxOY3IzYUtieElPTlRlZjRDWE5sdkkyNGZxVm80eWJZYjZWUklaRXVJcE5KcGNKNnJvUjFYTk9UbTlYX2FSZm1pcVB5Skh2NU80cWxMMVROUEdiQ0tpY2hlbUl0UEFud2RMbTBMRXZieWJBUVNSZHIxZjRIcy1xc1RUUmhxdHZsSkV5V1p6eUUwQ3p3UVFsRGFSb0RJWVp0TzZQdVpiUjdTRG1LanRNRXhSNE9HYTFFc2RjdnFqNGs1bWQyTDFBV2s3UQ?oc=5">Unlock Actionable Insights from Unstructured Data with Cortex AI - snowflake.com</a> - Wed, 23 Jul 2025 21:17:18 GMT</li>
       
-      <li><a href="https://www.snowflake.com/content/snowflake-site/global/en/blog/ai-ready-data-products-snowflake-internal-marketplace">Best Practices for Delivering AI-Ready Data Products with Snowflake Internal Marketplace</a> - Thu, 31 Jul 2025 09:00:07 -0700</li>
+      <li><a href="https://news.google.com/rss/articles/CBMikwFBVV95cUxNaXY4dHM1ME9tRUhTbThtLTB1M2pXT2tSNjV5NWZ2VFp5RVM4Q2ZLYjVlbFhIZTIzZmZ5MmhqOE91bnBiX2xvV0Q1MTlQem0yZlhoZDdCazRNTlVuQ2xfTnlPUWE4R0RBZmFYaElteXBDbVhZTkhLT040QUMxRTc0TzFzU3U2Rjl2VG1hWHNRYTVnR28?oc=5">StackAdapt unveils Snowflake native app for first-party data activation - PPC Land</a> - Tue, 29 Jul 2025 20:26:28 GMT</li>
       
-      <li><a href="https://www.snowflake.com/content/snowflake-site/global/en/blog/hightouch-snowflake-ai-marketing-ventures-investment">Hightouch and Snowflake Boost AI-Powered Marketing Data Stack with Snowflake Ventures Investment</a> - Tue, 29 Jul 2025 09:00:00 -0700</li>
+      <li><a href="https://news.google.com/rss/articles/CBMirAJBVV95cUxNQWZTajRFY1B2c3JjbmxxVmoxM2FuVUpyWnowRHZUWTJIM0gzd0VlMzNIZDlJTFdoS2NWUVpEUE96dXNDZDJwUHdpY3I0Ykk0MFUyV2F6OEtpa2lKako4MUZKWnZSeFMySTVIYmtfWjJ0Tzd5ZUZZX1dvam9ZVnNNNFg2UUdNSFBROVk4TnZ6VGZVSHBTSTZqMWMwSVFRM1hPeHFfWnlmWEFKQlhraHF5VnRic3daR0x2N1dpTmNOM1owTmQxQlhDbkNTS3ZLdXFxcnpCbnVFazRpLXh4OVhUcDYza04wek56RFd1WDk2dTR6aXpOQ3dqaXdZUmhyVnotZXJTdFdEM0dfd0xFUmhGNGFCYUNhZFFBbmdxQnFxM0VNbEdWZ2Y1Vm5VX2c?oc=5">StackAdapt Unveils Snowflake Native App, Powered by Snowflake Cortex AI, Unlocking First-Party Data Activation and Insight for Programmatic Campaigns - Business Wire</a> - Thu, 24 Jul 2025 07:00:00 GMT</li>
       
-      <li><a href="https://www.snowflake.com/content/snowflake-site/global/en/blog/snowpark-connect-apache-spark-preview">Snowpark Connect for Apache Spark™ in Public Preview</a> - Tue, 29 Jul 2025 06:00:00 -0700</li>
+      <li><a href="https://news.google.com/rss/articles/CBMixgFBVV95cUxPaFppdV9ndnJxenRQb0pFMExHM0pyT09hb1J0TGY1OWJPTHVBU1JyQ2tCMnJTSVN2dG94bU95b0xNa3g5Zk04UWhwd001LUhHT3pZbFUyVmNnQ0JEeGl3TmJyZmhjbVVyc2xuQXdpU3dpOVNDRGE1dVlzVFI0bjFsN3ZaS3UzMmFtVTVnODJwWTFIS1BBQ1U4Y2NQeDhqdUF2NGdvclUzSFkxR1d5NkFuelRjQXRaaUFmVm5tbzdVRUN4elFRUmc?oc=5">GrowthLoop Compound Marketing Engine Now Powered by Snowflake Cortex AI - PR Newswire</a> - Tue, 03 Jun 2025 07:00:00 GMT</li>
       
-      <li><a href="https://www.snowflake.com/content/snowflake-site/global/en/blog/sports-and-AI-real-results">Sports Teams and AI: Real Results and Real Challenges</a> - Tue, 22 Jul 2025 15:58:00 -0700</li>
+      <li><a href="https://news.google.com/rss/articles/CBMitAFBVV95cUxQY3c3M3JZeFpwV29QTXdWOTJzcEp2V1lvcDk3TEhPdTBIajNfa2M0TE5val9oMTVTS2Ffb1VrQ192WUJIQlhDTzMtT2Y3UF9LZHJtYWVmQWpFTDZ5aE1uaTdDazdtLVhkVld5aTUxMVRpMUJlTHhmc2lBbDR0WUxpYmJJdzBQSUE5RTZ1ODctUk93aS1SemxnSkZHRUpraTVuNk5pSG9nMVJ4endtZHhrVGpGUHI?oc=5">Snowflake’s Cortex AISQL aims to simplify unstructured data analysis - InfoWorld</a> - Tue, 03 Jun 2025 07:00:00 GMT</li>
       
     </ul>
     
     <h2>Databricks</h2>
     <ul>
       
-      <li><a href="https://www.databricks.com/blog/announcing-databricks-vancouver-development-center">Announcing Databricks Vancouver Development Center</a> - Thu, 31 Jul 2025 16:30:00 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMi9AFBVV95cUxPS2VNaWdId3VvOTF6TWVVczhOQ3NVdHNmYzdLVU1mUThfbDVNdnFIcXAxY0pwUlJtSzl4Qy1LXzFab3dFVmtKcTJ3Sm9HZ0YtSC1WMjI2MDg1ZTVYTzJpSXMyQ1FhWXByMW1fVjdnZk1USmJLZVN2UDNZYy1QLVpHcGdseFpsWGJfMTNWU1VXZXpvcVlCOHVDZGk4TkNISm9tX2psZ0lkTnNTVXdQUF83QXBKZlZOVmlDTV83N19XNjY2TjZValF0bXZUbzJwV2k0OXhwRTBGNkRXUkhNMnR4ZllkeTFwNlJSNjJRVVRBLVZEY2Jf?oc=5">Databricks Unveils Databricks One: A New Experience to Bring Data and AI to Every Corner of the Business - PR Newswire</a> - Wed, 11 Jun 2025 07:00:00 GMT</li>
       
-      <li><a href="https://www.databricks.com/blog/continuous-environmental-monitoring-using-new-transformwithstate-api">Continuous Environmental Monitoring Using the New transformWithState API</a> - Wed, 30 Jul 2025 16:00:00 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMiwAFBVV95cUxQMlg1V3FocmdEWEIwOW9KeTJTMVJHaUxHbFVNZWNXM0tFd0ROMUFMV09adDh1d0l1SmpEQTQ1aXB6RUJSZVZUbVhhWnFuWGZTa25jWDJNVDBwOU9rQUg5Y1FEZ05RN1RzSUsyMzRwMHNTMDN1XzNjcDNvQVpXLWNrTTNGUlA5MHR5QllMWnAwdGNrSVRCVF9nNG1LdWdVZUZ6RTdPc2JyRzhXbnR4MHBncWNTQ3dCc3VjWk56LUlzOWs?oc=5">Upskill your team on Azure Databricks with an on-demand webinar and Microsoft Learn - Microsoft Azure</a> - Thu, 17 Apr 2025 07:00:00 GMT</li>
       
-      <li><a href="https://www.databricks.com/blog/power-rlvr-training-leading-sql-reasoning-model-databricks">The Power of RLVR: Training a Leading SQL Reasoning Model on Databricks</a> - Wed, 30 Jul 2025 15:15:29 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMi-gFBVV95cUxPSFlZb2xEV29UMTlrMzJEdVA4cnNWM280bDhUMW40TThBQWNXdDZBaWViTFkwOXBCX0VkTHpqaWtyM0F2TTc5dFRTWUtwN1FLS2M4SGZJQzRtWE1NdlVqU3c1eTlqZzVoQm5fTk9lclVrRmdLRzEwNXF6Y3FXZVRxT18zaTJGMm9oQ2tsX1ZqbGVrWGxGYlZpZ21KWGFsLXZ3eTREdm4wd1FscTc1cTN1TG5QMmJNZlpNbWZITHI4blBoTEdkX211em5xWGlYMW45SDljckpwVm9sQUZnVHVRQUo0SnYtam9wYXpNV0dONUpNWTRBNHNLbm9n?oc=5">AtScale Powers Databricks Genie with Semantic Layer Delivering Accurate and Trusted Natural Language Querying - Business Wire</a> - Mon, 10 Mar 2025 07:00:00 GMT</li>
       
-      <li><a href="https://www.databricks.com/blog/whats-new-aibi-july-2025-roundup">What’s New in AI/BI - July 2025 Roundup</a> - Wed, 30 Jul 2025 08:07:33 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMiqwFBVV95cUxPb1pjRVZFYXRjdzBJYmd3dmUxSVJCTVFtRjRzd0lrQTNvd3l1WkgzalZaSWlBZ1NrQlF0RnBRMlNCRFhBdm9tWVRDRXZQVF9yay0tbUVSRmROa1ZkLUp1M1Utb0ZBTUhieUJsR05nNWZybTVWeUMxRl9mSVlLdVBXZ2IxRUF4bjZ4aW9wNXR5MFg4eEphQWpQcXZpN0Z4LWpCU3pHcFpkUEhPRjA?oc=5">Databricks One brings data and AI to the entire organization - Techzine Global</a> - Thu, 12 Jun 2025 07:00:00 GMT</li>
       
-      <li><a href="https://www.databricks.com/blog/smarter-decisions-scale-how-lotuss-uses-ai-and-nlq-empower-3000-stores-real-time-intelligence">Smarter Decisions at Scale: How Lotus’s Uses AI and NLQ to Empower 3,000+ Stores with Real-Time Intelligence</a> - Mon, 28 Jul 2025 18:30:47 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMipgFBVV95cUxPbHJ4OW5ZNEdxc1BFRzUtcHBrMG1vLU9YOENZSXVNZXJnbjR2cy1DSUFIZnpwZVhKNkFqaEtxMTNielVnUzM2aWdqdENaM0doYkU4eWZ5MDU1eS1CU0Y0M0hGWEJXaDdFUmtGZHUtQVlfUzA2cGt4OEYyemltVEd4T01kRWxWejRTRzcxdkFuMWlhNEs5SjFuSnBOajB2ZXJNMmVSZWJB?oc=5">Databricks kicks off an initiative to make AI agents easier to build and manage - SiliconANGLE</a> - Mon, 10 Mar 2025 07:00:00 GMT</li>
+      
+    </ul>
+    
+    <h2>Qlik</h2>
+    <ul>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMivwFBVV95cUxNbTlqOXB6anN5T0JTbmhldWR4MUVhVWs0ejJkU3B4VDNyWmloOHN2YVJGV1dmTzJNWUd3ZGpwOFE5MUZwbmctbllSU2pjMlBIUVMzYTF5YW9BVFZUVXJDMnBuX2xSTnpGSTNjWmtTaEw4N3BBUzgteXRIMUdYZTdwUE9UaWpxUS0zeGRQc1lBV3FXSmpWS3FuY2tTbzBBNjZ4cFAzQ2hJSWl2ZHVjTGVLeGxKdWpmWXdtR1pNT2YzMA?oc=5">Hydronorth boosts efficiency and decision-making with Qlik’s data platform - Intelligent CIO</a> - Fri, 01 Aug 2025 12:40:50 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMi3wFBVV95cUxNbjRQSUo4NjZLRENKd3pTTTNYQllPQm5qbHhvMGNLVWpuLWlOZ2FMQ0pFOFZKSGNSVU1BTTBVRmxkZ2tDaHhQUWs5aFVWdkM5dHNYSDA5T3hlSktGemw1LUhhRENQWmktZi16emJFQk1pMGt0eE0yMnVKYzFqQXMxRGxhZ0pWcU1meld1bUFETXFNdUZZa2VIcWpmUU16RlQ3TFRFOG8ycTI5UkNKOWM3bDJLOU9qRFA5bnFwWVBRbUtxNVR4SWxwNmU5MlNTb0xxVWVPbWtRbFdURnpHVTZz?oc=5">Logistics Plus Outpaces Larger Rivals with AI-Powered Supply Chain Intelligence from Qlik - Business Wire</a> - Tue, 29 Jul 2025 12:30:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMimwFBVV95cUxPLXNqdlctT3J4S29UWlRmMVdVSFBaZmN6LUhObnFaMzNmVjEtM1d4NXlscnFsdFg0TTF6cUVIQUFOcDRsT3lNUEVJMFZVNDFWUWIwS2FFaWhBcVozMG80eFZOWktoZWxlX3AwSGtjYWU5TVdQV3RDUmRlbHl2NFZTM0lKSnQ3VTVHTnJ4cFYzOFdTcjRzeEViWFhsOA?oc=5">Nissin Foods taps Qlik for real-time ERP data and analysis - Frontier Enterprise</a> - Thu, 31 Jul 2025 03:00:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMilgFBVV95cUxOTk56RGsteXAzVTVoLThEVVdFMzU1emwzRlF5RDNHZWVWd3ZwWVJvaXlEX1FpaDBxYnNfTnBlRThWRUpnQVpXMEdzTlBidTBBSFhGcmJPZ2ZKcnZ5dXRoN1k2bFdmS2VycjRqNkhSSUc5NVlVYms4UkhEUHFrOUtVQUdBZ1dnbThndzg2YlFlQXF3VXRnbWc?oc=5">Qlik Launches Cloud Data Lakehouse, AI Agentic Capabilities - CRN Magazine</a> - Fri, 16 May 2025 07:00:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMi4AFBVV95cUxNeXRpZURWZVd1bERPdEVtSkFRdnhKUl9qejdpNFdaSGJxOHZ2d2ktSXBjTmlScnRxM0g1eW9HWmFHRUtYWGttYS1NYW9sYWd1VnBvOWVjY2hiOFFTSEFrX204T1M4TGE4RTh6V0RxZ1lyaGNCSzhJZHJuRXYzZllxVUY3WnBYUlZXZmUyUFlOZzhJdlM0QnNRTzMwcEdxd29Pa2I4eTZ3YWxuVGFvaFFmb1ZTSnJqcVktS0Zlc0drR1VlVEUzeHpzSUt0Mnh5SEhFY3ZkWkVpZTRLVDZmaTlHQQ?oc=5">Analytics and Data Science News for the Week of May 16; Updates from Alteryx, Databricks, Qlik &amp; More - solutionsreview.com</a> - Fri, 16 May 2025 07:00:00 GMT</li>
+      
+    </ul>
+    
+    <h2>Google</h2>
+    <ul>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMijwFBVV95cUxQMkZjOGswTUsyMEdoSlE2bXVhSlI3NkZwM1pnZXZfOTBySDU4TzVPZWIwY29GT1BYNFJwMWtiWk93WDdoUkkxLXZQdUhuQzkxYUdDWEVIUUZmem9KSDRxNkRxX0M2VTVWU2poMXd0ZG05MzFGcGV2ZlFZLUtqWmREeXpzSTBSd3ZFYWxXLVlGNA?oc=5">Looker Studio introduces Code Interpreter for advanced data analysis - PPC Land</a> - Tue, 29 Jul 2025 05:33:01 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMiuAFBVV95cUxOeFJ0TElWbTQ1VUZIRWtqaDlLQ09rbXpEd1c5YUNoRUtDRmdzNndDOGRNTGYtenphOURGMUFuYWNZQzhkcXJZYnhDbjJUZzZTd0NpOVJNNGFaRVBaNlJzNnpId3dGUExIN1RpdXpzSm0wcFFOOXVmemlwVDkzQ0swZndUem82X3ZfT2ROSHpVQW04Y3NuNlFOUWg4SlZVOE5qS2NKQTdyc3RJWHNlVS1LYjJxZDJUS1dB?oc=5">My Experience Switching From Power BI to Looker (as a Senior Data Analyst) - Towards Data Science</a> - Fri, 17 Jan 2025 08:00:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMirAFBVV95cUxNWHptb0NtcF9rZ2xuT05TZ0NfYkQ4OG4tcGZTb2VBNW1TUkpWNm15LTU1MG9VUXFxT21zcGFOMjhySzRSOUxtbThES1FCZF92U2xBTVhYVGdGWkR6S0MwYXJ6NTdES01XMUtkb29nS2pTY3RKVmJES3o2Qk5oVG9Wb1V0NGlvQmpKSEFYS3NWWmlFb3R4VU0zM2ZnbFg3RUJVelJEc3ZaWWhUNHR0?oc=5">Google lets AI agents do the data work in BigQuery and Looker - Techzine Global</a> - Wed, 09 Apr 2025 07:00:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMiswFBVV95cUxQSU9Jd1pKMTdXU3BBd2RjWUs3Mlhta2w3enI1Wlp0dENyWWxZdVk0SXNGMTFzdHZRZ3ZKUU9SUTBtR3NKX0h1MnE3MnUtVmdYZ3NrblQ0aGhXVXkyM3VTYURUZW1EbEFVYVFEa2Q2cTRsaEpDM2drUnpxOTQ3RnJITklBdlJLS2JOWlNTM2lnZGpIZzNHQlUySUgxM3RtRTZLZjE0VGJra2tEQ1hsSklqSnc0SQ?oc=5">Google’s BigQuery and Looker get agents to simplify analytics tasks - InfoWorld</a> - Thu, 10 Apr 2025 07:00:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMizwFBVV95cUxOdkx2ZnYwYVlpU1hEcXF2T25mZlFfS1JBeXdHWng2OEtGSndNcnRRTGQyZTI4WEtmS0xWQzdHaW0wbFl6NEZuZkJuZXdTVG96WnNNZW1MRWJxY1cxUzFLNk54d2ZBNEkwOEhoQnlvNWRwcTRkVU1EM0dVWDI5dTBrN1dpaFZ3NEhVblJFLU9ZUjhDVGlVZU5GT3FxSGJmZndwejFSczNmTDBDOVA5SW1MSXpVVy1FeUphRk5tSWNvQkVOVDgxMGdpSzBVelBLQTA?oc=5">Fig. 1. Visualizations from the SARS-CoV-2 Dashboard in Google Looker... - researchgate.net</a> - Thu, 17 Jul 2025 05:54:51 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMiakFVX3lxTE84QWt6azVIbFRwVGpFbXdzSFdsakgxamdmZS15NWxmU1luVjlMUHp6WV9oRVhJa1dMRFJHcTlFRFNvM3dKUGZkNF9fZ0x5T2RJQmFQOXJhOWI3bmZDXzZnb29xaVJIQ0VmaFE?oc=5">Try Deep Think in the Gemini app - The Keyword</a> - Fri, 01 Aug 2025 13:27:45 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMifkFVX3lxTE9veW8zSGE1NzBJSDVUeXRndi1QbU1pUUpFVmYxZUh5RjNLN29zWDZBQmxocHpXOVlteEt5MWg5S050VnByX2owZk9HZTd3enJGOHRvMnVEZHFzRnJjN25oNktRSzl2Zmt5dXJwaEJpU0hsTjJSMG9BYnBzb1BGUQ?oc=5">Google renames most of its new Gemini-Assistant voices for Nest [Video] - 9to5Google</a> - Sat, 02 Aug 2025 19:05:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMinwFBVV95cUxNUGltRk0zdTdQeFhZOUNrM3RfUy01bTdtTzRFOE1kRnZBSWt3N185SkJUdEE0RHJvWmhzejBOWFlWdGh3MWhLLW9fU1MyeXo4S3BrMHdEdmFfSFNtUlllYmlKMFJDU0F1aTZiTTl5VWVIZlpCWkM1WmRLNmRqSUJ1ZXpUYWJueGoxamsyU3Q4RG5FLW96Mi1SNDdhdExIYUk?oc=5">Google releases Gemini 2.5 Deep Think for AI Ultra subscribers - Ars Technica</a> - Fri, 01 Aug 2025 15:36:08 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMixwFBVV95cUxOUzRFWHA1QUZPeWhISThpRlNTRk9sWjNIQzlmLUpsZWp0azBEWTlhdkN2TzNndGZCWjg3QWJQSHptMTR2QkVlSF8wTjY4MjV2Wmo1T2lubU1URWNaSHhwQUlXdXFPc0t1SnltSU91S0dPVXdBcGhVVi02MF8xNUFNSWtiTVd4WWt1TFN1am5UT0hmZkE1NUtRUkw3Tnd0bHl5Q3RGSF9xWlFvU0t6cEtXQVhEWUJnX1JmSWlNaXc3RHRCWE81cFVZ?oc=5">Google rolls out Gemini Deep Think AI, a reasoning model that tests multiple ideas in parallel - TechCrunch</a> - Fri, 01 Aug 2025 11:00:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMipwFBVV95cUxPOXlmY3BjWU1mNWVVVzNzZU15empRcXd2RE0tb0k5ejRJTUxNODhCcnZfLW1MTGJqVS10MWtfc2FfYWdVb0s5NnlEOVZrVzVJdnJGeTM4cWhXUlFYTGNGdjdSU1RPNV9qOGJ3VzcyUmZiV3UzYy1yMzhqM2FuUVhXMzlTMDhwbngzVmUxcHF1VnYxN1lHa2dZQzFPWHQ5cExWRGRrdHd6WQ?oc=5">Using ChatGPT or other AI tools? Here’s who can see your chat history - Fast Company</a> - Mon, 04 Aug 2025 10:12:28 GMT</li>
       
     </ul>
     
     <h2>Agentic Analytics</h2>
     <ul>
       
+      <li><a href="https://news.google.com/rss/articles/CBMiogFBVV95cUxQbGcwMkV4RnUtcVgwTDJ1NXd6RHFYV180Q0U0enVKRjlLOF9obk9uQkFQcnllMW9DWWFVLVlvcDFUb25iRDdFVF9Nc0lMdzktUV9WdmZRRk5adGxVZEFzbjZLMkJidnJXY3lDdHZwS2RTcTNxMm82cE9BYm1tQzEwVTRvRHQtMDlWMHRYZlFqc1NLRHJVMG91SVVsSVczY0loblE?oc=5">Agentic AI could be the Breakthrough Indian SMBs were Waiting For - sify.com</a> - Mon, 04 Aug 2025 05:17:12 GMT</li>
+      
       <li><a href="https://news.google.com/rss/articles/CBMi1AFBVV95cUxQUTNmOUgwN1VSUlBYSHRSM3BoSVJjTHlndnR5QkdmTS1EcTl3akJSX3N2R3ZKY2ZtOTVscy1nTHY1RnpTY2tEUHk2OEplc05PS2FNMklVRndOMnZ0cm9jTVV3S0pfQWJRSWZuYXVIVFl6X2NnNzBkaU03VmI0N2VnczVsOVg0eEJoUktfQi16Ri15VkR0ZElta3lUdXpRQUlWcm04LTh1ak42Q2tWcGtkOXZiMXdWWmxXb2V0TFctRnZfUzFqaHZnLXVpNWtUcFg4YU5HUA?oc=5">The $196.6 Billion Agentic AI Revolution: Complete Market Analysis, Statistics &amp; Growth Forecast 2025 - Australian Technology News</a> - Sat, 02 Aug 2025 03:05:18 GMT</li>
       
-      <li><a href="https://news.google.com/rss/articles/CBMi8AFBVV95cUxOa0JVdjIwbWM0M0VaX1NLTzBVcXpTOUpRVWNwNERHQkpTU1JFclBIQ282M1hCR2s2ZE43bXczal9CamVUZWJfQkdGc3dHaklLeWJ1RjMzcWJHZldIQjdMZlVyQ1dnTnJLX3MwUXVkbnBiZmxNOXE2azN6ZUJRNElLZ1pnZzQ0MkRKdlBOZUZXTDdpTTNYVVNWbzV4T1lodkVlakNaci14bjhRYUJ0cFVpeS1jTWIzMjNXbTRFVWQ1SG9OcEEtaDBSMnlJd19Jd1htbVRiZHhfRDN1UTczemRGTTJWcm9XSWVtcXN2WkxyUTM?oc=5">ThoughtSpot Redefines AI Interoperability with Launch of ThoughtSpot Agentic MCP Server - GlobeNewswire</a> - Tue, 29 Jul 2025 13:04:02 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMiggFBVV95cUxPc1d1RE9uYUdqeGpqeGFVMFNDR1oyM1hIM3lyNTd4UEZmWG51MkhLTTFWQ2JjZ2ZuYjE0bE1DTHBpQWMyb1hhVmRTRWVoZ2hKRVZFbXF1VFJheU4zcXlGazhzMGJidE0tWUJ4U1IxWlBDbjJFczk0T3MwT2xTNE5JNjRn?oc=5">Qrvey 9.1 Accelerates Embedded Analytics With Agentic AI and a Faster Path to Deployment - Yahoo Finance</a> - Tue, 29 Jul 2025 12:00:00 GMT</li>
       
       <li><a href="https://news.google.com/rss/articles/CBMixAFBVV95cUxOeExheFhKXzBBZTBfYkFmRE9KV1RIUVdZR1hyV0VEZ21PWGFWRDB0TGRxVE9zcFR1aS1XTmtZNS1iTzdaWGdEb0dQX29DdjczLXRJV0h1S0ZrYUU0SXFOMU9uQ3pHLVBrbTRUVjBkZkIxMTMxdmM5Tmw1azZjRlJwWjBjMVJGblhtRGdJTVpHOFhFU3psRERvSTZ4QTNRNTlmX2VRYXlrWmdUb1pON2hsQzRiSzdoTXVUUm1fOGJsQ1hJNVh2?oc=5">Momba launches agentic AI solution to transform business analysis and project delivery - AiThority</a> - Wed, 30 Jul 2025 15:09:20 GMT</li>
       
-      <li><a href="https://news.google.com/rss/articles/CBMirwFBVV95cUxQM0ZlR1pIUW80R3U2bmdfdVZ1amcyVE1Bd29WcXF0eThUVHdGcE1fX2luMm12YTliVGpHVHhBbjlTYkFMSkR0VGtlTFZCWjNiTmhzZGJwSVc3aHdhNEpDTkVmQWhYWUtYdFNkQ0E5YUpXWWNETndyODNQOHRLc2tvSzh3dUxNczFpR3NVY3dsX1E4TmtfaDlvZGVOamNNaVBLQXVtdDBnNV9Nd3hYVXhJ0gG0AUFVX3lxTE1YTk9oNjRmbXdvN2JZVHU1SDF6NmVlMEh1SUJvLW1LYVV6QzVFRUNMc3V4cEZCTUd0dDFQbVBRVTN4aXFGZDd6X2IwX1NaTGE2ZmdCOWRiTTZYNTQtRm91b1dYTnFYZEFYZy1LcWpIUDBzMkJxZ3BlRmdoUnEwaG5FNHBIdjBIQm9TajZoS3ZhaTlOMURncTJBVUpoQkpmbXVRT1pKT2I1WlFmZGlaLXhHelVmaQ?oc=5">Getting real about agentic AI, from protocols to data platforms - more inbox adventures with AI vendors - Diginomica</a> - Tue, 22 Jul 2025 07:00:00 GMT</li>
-      
-      <li><a href="https://news.google.com/rss/articles/CBMiggFBVV95cUxPc1d1RE9uYUdqeGpqeGFVMFNDR1oyM1hIM3lyNTd4UEZmWG51MkhLTTFWQ2JjZ2ZuYjE0bE1DTHBpQWMyb1hhVmRTRWVoZ2hKRVZFbXF1VFJheU4zcXlGazhzMGJidE0tWUJ4U1IxWlBDbjJFczk0T3MwT2xTNE5JNjRn?oc=5">Qrvey 9.1 Accelerates Embedded Analytics With Agentic AI and a Faster Path to Deployment - Yahoo Finance</a> - Tue, 29 Jul 2025 12:00:00 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMifEFVX3lxTFBBOWtyNmdRMGpPMWlyNXBMaGNLLWhncm51cS12SWFZZzNvU2UzaEdmbExPbGlFTU45ZVl4bXlRczQxbEpxUWVPYVJIaFZpRGRQWkNGS1IyTTM4cVlYcTlZN0NqZ1BraXQyNjU0bzVsd3JRT0V4QllxdE5ta1Q?oc=5">Driving Business Value With Agentic AI - hbr.org</a> - Wed, 16 Jul 2025 07:00:00 GMT</li>
       
     </ul>
     
     <h2>Data Analytics</h2>
     <ul>
       
-      <li><a href="https://news.google.com/rss/articles/CBMiwAFBVV95cUxPTDVyaU5UTUZ4V2JGYmM5ZklnUm4zZ3RrdElBZkdJU3l0Y3FVVkJuYnp0VmJRS3dNOXNZbXdWUnJweHprQWdsV1ViWC11REdlSDU5T2NpcTNVZmJoemdHeWltNVc4QkNZYkY5OUpJcWl0dmZKXzhTZTBpanFCWUFNd2RYUGlFblByaHNaS0ItSndVcWNiczNOMXktZWoxdEFKdnVaNy1CLUo1c0dqUFhVeTBTaVlRSVRzLXRHUXRsM1Y?oc=5">FinTech’s next frontier: Unleashing growth through hyper-personalization and data analytics - BusinessCloud</a> - Tue, 29 Jul 2025 17:38:49 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMihgFBVV95cUxQTHpCWlB2anVybmdfNExhblVVLWsxYXk2Y080SzRfWGszWXRGTXZQeDZHXzRVTW9Ga1ZkNlZDSVN3NkF0ZFZpR2lDaVRNMmlwaHgxVGV6V3lzd0VJZ3hoaHFvMFlVWHlSdU1pOFBVSVM3cUdsVzdaVDJwanJvdlU2TVFRRzZqZw?oc=5">Pamplin students leverage data analytics to improve the undergraduate experience - Virginia Tech News</a> - Mon, 04 Aug 2025 14:26:14 GMT</li>
       
-      <li><a href="https://news.google.com/rss/articles/CBMirwFBVV95cUxNYm1Ca3BublNzZWdiMFp6aVFvX3VsMmVQbkRWSmZ4OWpfcDhPZzZDeEp2d25hY19oQjREXzJPNVg0cGpISW9mVHkxOU80aG1BclF4allwckFTUlFnUGxwbmpqdVFKaVdERDRkVjJZUkUtR196dnhxTlE5YWdyaHZLdEc5STNZMjd4QnpmQ1BjamdMRmxvU2IyVzk5UUlTMURxaVcxNkhna0pHRlFUZkFn?oc=5">Prep data for machine learning with AWS analytics services - TechTarget</a> - Fri, 01 Aug 2025 16:30:17 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMiuAFBVV95cUxOU2daT1RCTEl1Vl9zN2I0Uzg1em5ITXJLT0ZWZk0wWW55dWE4cUNIUHFMMGdteXN3WjJTSEJlbW4ydnRLaGhIOWdhSnBJTlNlY2M5dXdpUlVpY0JZemE5MHZyMjNiYS1aSmJqbHpLa0UxTG9UemJsaHc3MG5HMFB1dzZqSWFoalR2enNNVE1sc2lmVXVxNnpodWYzTXZEYUJrbThSd0l1U0pOQl9zUDEyY2VuMFlZQXhu?oc=5">6 U.S. cities will get data analytics, AI support via international alliance - Smart Cities Dive</a> - Mon, 04 Aug 2025 16:42:36 GMT</li>
       
-      <li><a href="https://news.google.com/rss/articles/CBMisAFBVV95cUxNdjExeTM2NXlNa21vZ3I0SWVfS2hlWWJUZHZraHp2c1JvSzktOEdhR25pYVNvVlhkR2NaWE1CS2l5QUpVX1VpMXFpdXYwc0ZmWHlLd2JYcGFDM01YTVN3cWVfXzdtNGtNMjVzUEs1RDBMMW52dThWYmxwY0NZc19zZFVSdlhWNnVDaXpsVVhlU0pKQmlmR1g1Sk1JNU9OR3dtQUtram0yUlBzZDEyeHNiLQ?oc=5">“I think of analysts as data wizards who help their product teams solve problems” - Towards Data Science</a> - Fri, 01 Aug 2025 14:39:53 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMiqgFBVV95cUxPTnNMVUJQVEc0NFpYajBxOS1ma1VBUXc0MlNzTE1VZXBkVDFLOWZYaFgwYTQ2WnVrUkZEYzl6cU1BcFprWk1GcnpFUGNqcGRtR2VmN0ExYlFkYTQtNm53UWJzRkZfdHR1VjVKVVo2UmFnb3N4dGlxT2Z5TEhCaVYtN21scUxmbWRLSk9NRS1FV0xCa1FZczRYZHBYbnpjN180Q2VmTm9sRXMwZw?oc=5">Near real-time streaming analytics on protobuf with Amazon Redshift - Amazon Web Services</a> - Mon, 04 Aug 2025 17:06:42 GMT</li>
       
-      <li><a href="https://news.google.com/rss/articles/CBMijwFBVV95cUxPSUxGM1pBU2t4YWNzR0d0Q19MUzdlTkF5ZTNfd0FSVmNJVzhYT1M2ZDBicDRtQTJ5bHlDVlVTR1ltaGJxbkJLenR6OVNWUERiWmNNM0VweVhSendTUDlIR2tDYWp0MXVLWUlXR3RrQnE3UWE3U0I5ekdlbnR2SWE5eTVVM2JfYV8xelpkaXFWUQ?oc=5">Data Science vs Machine Learning vs Data Analytics [2025] - Simplilearn.com</a> - Thu, 31 Jul 2025 07:00:00 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMigwFBVV95cUxQUUFzdjhOSzVlcmhNcWRuZlRGYzZCc3E3T1o1N05xWXVhV2Y1R3NXOFVIMWlQUTRtZVNYV1NVTUVmMEx2dHktU1hWT2ExU3llblg0UXlSdF9nQVFaOVJTWl9Oc0Z1YUl5azctYkNxem5ReTRWNFRCUDU3QVlPc0Y0aklVZw?oc=5">From Data Scientist IC to Manager: One Year In - Towards Data Science</a> - Mon, 04 Aug 2025 19:11:05 GMT</li>
       
-      <li><a href="https://news.google.com/rss/articles/CBMinwFBVV95cUxPMEQ2cno4X2VmMkxOMEN4TlBTdTU4WlhBOUxkNjAydzN0V0tEbzdGYW5UdHRsUWtoWlppczk0LWVIdGZYTXF6ZHV0R2FCSktPTGxVTlBmYkRLbWFyeFNtNVQ4RmtFQ016UC13V1pUWDVGS2NzV0QwdElud211cFFsN1JFTlFoSU9jWlJwUm9kbkNINmdRcGVveDVSZ0FvOEU?oc=5">Careers in data analytics: a comprehensive guide - BCS, The Chartered Institute for IT</a> - Tue, 13 May 2025 07:00:00 GMT</li>
+      <li><a href="https://news.google.com/rss/articles/CBMiakFVX3lxTFA4Um1xUXNfdkdPYTRRR2J2dWpMR0NFY05paFRmVUZHdTQ0WXhxc1JteFhDLXFKUV96OHhvUzJLV2xxVjBXYmgzYTdYM0daWnRVclFBenRqeF9FTDQxdks0QktibnNudnhmb0E?oc=5">Energy Data Analysis Platform for Analysts - Vortexa</a> - Mon, 04 Aug 2025 15:06:46 GMT</li>
+      
+    </ul>
+    
+    <h2>OpenAI</h2>
+    <ul>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMieEFVX3lxTFBfdDV5cVBJTC12NTB0ZmlpRXM3WkNrak9xY1U0TWdWOTBpeTA2aVg1ZUJpTUNobE81SFVramVYVGFaWDJxQVRRcFFvWXhlN0s4RXo0RFNZZUkxS21zNkpkcXp2YUlua0dEaHo5Y1FJNVpwVTBVU01Md9IBfkFVX3lxTE1XQUc0eV9rNG1aNWE4d3NHYVFMNGNseW1VZDhPT092M2k3dm4zSUs1ZnZGMm56RThTTzJfb2JmcGJvRWpXWnVLX1NqODFGenFVVWdxcjEwRWhpY3YxT19TVnFvWTJJMnk5WVZJY25BZUVvRGVpanBXeWdjRkxOZw?oc=5">OpenAI’s ChatGPT to hit 700 million weekly users, up 4x from last year - CNBC</a> - Mon, 04 Aug 2025 15:00:18 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMimAFBVV95cUxNV2lnMjExSUpLZWtrNktJNUxxYmp2R0FhWW5uNHlPOTVQQzIwNkl6cFJtMG4taXlyUzlFdXdGYmVxNjluUUN5LWlraW1ScHZQTnRjUTRpR2NhZE1oLXpoa1Z6b2xrVHhOcXZ3MHpoQS1uNWp4VkRUam4xNUl2VDlkUE42WHNUbVo1UFdkZnhSQ3pxbWdjUnpvcg?oc=5">OpenAI says ChatGPT is on track to reach 700M weekly users - TechCrunch</a> - Mon, 04 Aug 2025 15:25:13 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMipgFBVV95cUxQTm5TeW1ETkUwUWJWZ2hpcTBIaEEzakdDblhhWG0xRnc5ejZTOFJyT2lBSWszbXR5SkkxZGwwWm1odkdWQkJWdDdqUm4tWFNreVAtUXBjQkktU2F3M3Q0SVZOenRrMFo3M0w1UGtaRGszV0J0d0ktYnVQSVlDdVYzTk1fN05oaWhvQlZnUTdrbDJleksyX0l4cDBleXFBMHRIakU5WUt3?oc=5">OpenAI Adds 200 Million Weekly Users in 4 Months - PYMNTS.com</a> - Mon, 04 Aug 2025 20:25:43 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMifkFVX3lxTE1FZTluR1ppd25WVU9xTWctekxIVVltaDJOdjM3SDVUbGZHT0lxQ1plYUw4THBJenQwbUhXQTRnTHdRcmU1a2V3QzM0ckFIYzloM2YxMTN0TW81dFFxX0JpSU1RMm8wMEZlbWl6Z3VOOWVQZ2hzRndha2RoeG9sdw?oc=5">Sam Altman teases GPT-5, asks it to recommend the &#39;most thought-provoking&#39; TV show about AI - Business Insider</a> - Mon, 04 Aug 2025 00:27:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMijwFBVV95cUxQQkZ2LUxGMjYyRkZzSjVTNjlna05MNWhsaUZ6Um9JSjdIaWdKZktGVUJrUVpnaHpuTG1EX3RaQjFqenlSNnZSc2FCUmdHZzdFZTVISTJ0V3g1QVlDRk1uVVNFcm94M0NDRXdjM1FRUW14eEVQMVZMbTdtYUpxamxjYm8xbDNjek0yelNNcV9pSQ?oc=5">Inside OpenAI’s quest to make AI do anything for you - TechCrunch</a> - Sun, 03 Aug 2025 14:00:00 GMT</li>
+      
+    </ul>
+    
+    <h2>Anthropic</h2>
+    <ul>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMie0FVX3lxTE10QjlFRm82MUZVTDU1Z0FSdGo4MTVCQm5lUFowLWhoZFB2cjFwV3hLek9wejlEc2liN2FLX0pTbE16V1V1TmdNcUhRU2lwMWh5WktMNzNkWnE2LXRXQ29oTUtVYlZKbThUcjkxZ0NDVG1fSkVOZVFWMVd0aw?oc=5">Anthropic Revokes OpenAI&#39;s Access to Claude - WIRED</a> - Fri, 01 Aug 2025 21:41:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMi6wFBVV95cUxOQXFsNDRkbDlNNTlDTmE3TUlHUGphMjVWY25pNDdJcUZ3TFQxWEZvMklpaE15cy1jVDhfUGhEZXk5dWxGN0g2OXpDcVd6MllHT1A1ay1mN2xJcmlyc0owS2x3ZDBuZjNScnBabElvMTl4WW1wNFFZd25sYWlEY05lLWdabDViSkZQMTdJTVpELXFzT25fUFBWM3FyOVo5WWUtX290M0h4LVBYUDhIZ1gzYWFDVTRpYXhuazc5el9JWWJLb1k1TEk0M1JLbS1Qenk1RFRIQVk4MlFmUmlhU0hjNWRnWDJVdTMyVjhV?oc=5">Anthropic CEO Dario Amodei says his employees are refusing Zuckerberg’s $100 million payout—and he&#39;s not even matching salaries to keep them - Fortune</a> - Mon, 04 Aug 2025 14:36:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMikwFBVV95cUxQY29pVFlFWVM3bGhiSXJaVDRpRzRLcHdrb1ZUeVVDWDNZZlA0T3dkdTh1bzlEOGxvb29EV00wR3gzaTYzV19HemNyNXhjTkVMenJEcUZUZnBLSnp4cEpTNUd3UFpGOEN2ck8xQW5GN0VNeVlhQ01SbXNuTWFJMVRRUk1qY1BMOUhXVkhjd05lSlBnWmM?oc=5">Anthropic cuts off OpenAI’s access to its Claude models - TechCrunch</a> - Sat, 02 Aug 2025 16:55:12 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMiqAFBVV95cUxON1NPb0xjR2ZRdVBRUW41eFFKVlQ2bmRTMVJoblc3T3gzX1kzY3h0Z0ZnbllTNzYxM2VDOTBiYUtRRkdkdUJYUGxLaDRpNGRxVlV1eWp0ZU1hS2FBSzJJN24ydXRUNGpfaTFXWjNOSktDcUFqYTh5a1VvQzBPTmVza1VycnBGdE1UWFZBM1dlYnFXTUNMTkM0MXlKYkdEbWV0LXptQ2NMZ2o?oc=5">Anthropic CEO Dario Amodei fires back at Nvidia CEO Jensen Huang&#39;s criticism, calling it a &#39;bad faith distortion&#39; - Business Insider</a> - Fri, 01 Aug 2025 12:30:00 GMT</li>
+      
+      <li><a href="https://news.google.com/rss/articles/CBMirwFBVV95cUxPdC1DdlkyM25nT3dQNUF2V2VFTXNoYW5tQlJBc2VvTUxDcS1wTzlCZWFNeWxtQllvZjNCd3YxY3lxTlZXX0RRVHpyQWVNd2pjbkNVT3BRcHFTR19QdHhxRDEyY3dSRjI3X1NfZDhmd2g5ZGtrWm01Nm1tQzA5QnNHVW53ei15bm1naUR6LXFEczVFN2pMd28xZWlJOG1pZ0U5THI5UWpzaFNoSFBsdFB3?oc=5">Can a Chatbot Be Conscious? Claude 4 and the Limits of AI Understanding - Scientific American</a> - Fri, 01 Aug 2025 10:00:00 GMT</li>
       
     </ul>
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 feedparser
 jinja2
 PyYAML
+openai


### PR DESCRIPTION
## Summary
- switch site to white backgrounds with dark text and gradient navigation
- restore vendor folders on the Older page so archived stories keep their categories
- deepen weakness analysis with ThoughtSpot-aware prompts and contextual hints in article JSON

## Testing
- `pip install -r requirements.txt`
- `python news_agent.py --config feeds.yaml --output public/index.html --json frontend/public/articles.json`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c3609a4c8325995f340d71e4a95e