### PR TITLE
style: apply dark theme variables

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2,7 +2,7 @@
   --ts-primary: #4e3289;
   --ts-bg: #020202;
   --ts-text: #ffffff;
-  --ts-gradient: linear-gradient(90deg, #4e3289, #020202);
+  --ts-gradient: linear-gradient(90deg, var(--ts-primary), var(--ts-bg));
 }
 
 body {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,7 +1,7 @@
 :root {
   --ts-primary: #4e3289;
-  --ts-bg: #020202;
-  --ts-text: #ffffff;
+  --ts-bg: #ffffff;
+  --ts-text: #000000;
   --ts-gradient: linear-gradient(90deg, var(--ts-primary), var(--ts-bg));
 }
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2,6 +2,7 @@
   --ts-primary: #4e3289;
   --ts-bg: #020202;
   --ts-text: #ffffff;
+  --ts-gradient: linear-gradient(90deg, #4e3289, #020202);
 }
 
 body {
@@ -12,7 +13,7 @@ body {
 }
 
 .navbar {
-  background: var(--ts-primary);
+  background: var(--ts-gradient);
   color: var(--ts-text);
   display: flex;
   align-items: center;
@@ -42,11 +43,11 @@ body {
 
 .search {
   padding: 0.5rem 0.75rem;
-  border: none;
+  border: 1px solid var(--ts-primary);
   border-radius: 4px;
   min-width: 200px;
-  background: #fff;
-  color: #000;
+  background: var(--ts-bg);
+  color: var(--ts-text);
 }
 
 .content {


### PR DESCRIPTION
## Summary
- define dark theme colors via CSS variables and gradient
- adapt navbar and search styles to use the new variables

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891c6a53ff88325b435dad65fb6f6fc