### PR TITLE
chore: enable workflow content write

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,5 +1,8 @@
 name: daily-news
 
+permissions:
+  contents: write
+
 on:
   schedule:
     - cron: '0 7 * * *'


### PR DESCRIPTION
## Summary
- allow workflow token to write repository contents for daily update

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689948869b3c8325992348a69fd2edb8