### PR TITLE
chore: add PAT token to daily workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,5 +1,8 @@
 name: daily-news
 
+permissions:
+  contents: write
+
 on:
   schedule:
     - cron: '0 7 * * *'
@@ -19,3 +22,4 @@ jobs:
         with:
           commit_message: "chore: update daily news data"
           file_pattern: public/index.html frontend/public/articles.json
+          token: ${{ secrets.PAT }}


### PR DESCRIPTION
## Summary
- configure daily workflow to use PAT for git-auto-commit

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689948869b3c8325992348a69fd2edb8