### PR TITLE
Add Pyramid Analytics vendor feed and latest news tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Recent enhancements include:
 
 - Optional LLM-powered summaries for richer article context.
 - Vendor weaknesses framed against ThoughtSpot's search-driven analytics.
-- A "Top News" section highlighting priority competitors.
+- A "Top News" tab highlighting priority competitors and a "Latest News" tab for recent coverage.
 - Expanded feed coverage for OpenAI, Anthropic, Google Looker/Gemini, Qlik and more.
 
 ---

--- a/feeds.yaml
+++ b/feeds.yaml
@@ -39,6 +39,14 @@ feeds:
     url: https://www.sigmacomputing.com/blog/feed/
     max_items: 5
     category: vendor
+  - name: Sigma Computing
+    url: https://news.google.com/rss/search?q=Sigma+Computing+analytics
+    max_items: 5
+    category: vendor
+  - name: Pyramid Analytics
+    url: https://news.google.com/rss/search?q=Pyramid+Analytics
+    max_items: 5
+    category: vendor
   - name: Qlik
     url: https://news.google.com/rss/search?q=Qlik+analytics
     max_items: 5

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Section from '../components/Section.jsx';
 
 export default function Home({ articles }) {
@@ -11,14 +11,36 @@ export default function Home({ articles }) {
     'Qlik',
     'Looker',
     'Google',
+    'Pyramid Analytics',
   ];
   const top = articles.filter((a) => priority.includes(a.source));
   const rest = articles.filter((a) => !priority.includes(a.source));
+  const defaultTab = top.length > 0 ? 'top' : 'latest';
+  const [tab, setTab] = useState(defaultTab);
+  const shown = tab === 'top' ? top : rest;
 
   return (
     <div>
-      {top.length > 0 && <Section title="Top News" articles={top} />}
-      <Section title="Latest" articles={rest} />
+      <div className="tabs">
+        {top.length > 0 && (
+          <button
+            className={tab === 'top' ? 'active' : ''}
+            onClick={() => setTab('top')}
+          >
+            Top News
+          </button>
+        )}
+        <button
+          className={tab === 'latest' ? 'active' : ''}
+          onClick={() => setTab('latest')}
+        >
+          Latest News
+        </button>
+      </div>
+      <Section
+        title={tab === 'top' ? 'Top News' : 'Latest News'}
+        articles={shown}
+      />
     </div>
   );
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -93,3 +93,26 @@ a {
 .vendor-folders details {
   margin-bottom: 1rem;
 }
+
+.tabs {
+  display: flex;
+  margin-bottom: 1rem;
+}
+
+.tabs button {
+  flex: 1;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--ts-primary);
+  background: var(--ts-banner);
+  color: var(--ts-text);
+  cursor: pointer;
+}
+
+.tabs button.active {
+  background: var(--ts-primary);
+  color: var(--ts-bg);
+}
+
+.tabs button + button {
+  margin-left: 0.5rem;
+}

--- a/news_agent.py
+++ b/news_agent.py
@@ -126,6 +126,7 @@ VENDOR_WEAKNESSES = {
     "Qlik": "Script-heavy Qlik setup is harder than ThoughtSpot's intuitive search.",
     "Looker": "Requires LookML modeling while ThoughtSpot works directly on the data.",
     "Google": "ThoughtSpot's search-driven analytics is more intuitive than Looker/Gemini.",
+    "Pyramid Analytics": "Depends on predefined workflows instead of ThoughtSpot's ad-hoc search.",
 }
 
 
@@ -137,9 +138,6 @@ def suggest_drawback(
     if llm:
         return llm
 
-    if source and source in VENDOR_WEAKNESSES:
-        return VENDOR_WEAKNESSES[source]
-
     text = f"{title} {summary or ''}".lower()
     if any(k in text for k in ["security", "breach", "privacy"]):
         return "May raise security and compliance concerns."
@@ -149,6 +147,16 @@ def suggest_drawback(
         return "Relies on external infrastructure and possible vendor lock-in."
     if any(k in text for k in ["partnership", "integration"]):
         return "Integration complexity and potential data silos."
+    if any(k in text for k in ["preview", "beta"]):
+        return "Feature may be unstable or lack full support."
+    if any(k in text for k in ["pricing", "cost", "expensive"]):
+        return "Could add unexpected licensing or operational costs."
+    if any(k in text for k in ["training", "certification"]):
+        return "May require specialized training to realize full value."
+    if any(k in text for k in ["complex", "overhead", "maintenance"]):
+        return "Implementation complexity could slow adoption."
+    if source and source in VENDOR_WEAKNESSES:
+        return VENDOR_WEAKNESSES[source]
     return "Consider cost, adoption effort, and governance implications."
 
 


### PR DESCRIPTION
## Summary
- track Sigma and Pyramid Analytics by adding vendor RSS feeds
- introduce home page tabs for Top News and Latest News
- generate more article-specific potential drawbacks

## Testing
- `npm test`
- `python -m py_compile news_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5a76030788325b6d5f6cce90646f5